### PR TITLE
Minimal build fix in response to the request for help

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ clean-test
 *.dirstamp
 Makefile
 */Makefile
+src/EsterelTokenTypes.txt
+src/EsterelTreeParserTokenTypes.txt
 src/cec
 cec-strlxml
 cec-xmlstrl
@@ -48,3 +50,4 @@ cec-grc3val
 cec-grcbal
 cec-vm
 cec-vm-wrapper
+

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Makefile
 src/EsterelTokenTypes.txt
 src/EsterelTreeParserTokenTypes.txt
 src/cec
+src/test*.*
 cec-strlxml
 cec-xmlstrl
 cec-expandmodules

--- a/INSTALL
+++ b/INSTALL
@@ -312,6 +312,13 @@ workaround:
 
      CONFIG_SHELL=/bin/bash ./configure CONFIG_SHELL=/bin/bash
 
+Addendum
+--------
+In order for the configure script to pick up the antlr 2.x tool, please
+add the ANTLR_HOME environment variable, either through your user profile
+or by prefixing the ./configure command: e.g.
+	ANTLR_HOME=/usr/share/java ./configure CXXFLAGS=-DANTLR_REALLY_NO_STRCASECMP
+
 'configure' Invocation
 ======================
 

--- a/configure
+++ b/configure
@@ -18120,7 +18120,7 @@ options { language="Cpp"; }
 class TestParser extends Parser;
 file : ;
 EOF
-java antlr.Tool test.g > antlr-version 2>&1 || ac_cv_found_antlr=no
+java -cp $ANTLR_HOME/antlr.jar antlr.Tool test.g > antlr-version 2>&1 || ac_cv_found_antlr=no
 antlr_version=`sed 's/^.*Version //
 s/ .*$//' antlr-version`
 rm -f TestParser.cpp TestParser.hpp TestParserTokenTypes.hpp TestParserTokenTypes.txt test.g antlr-version
@@ -18130,7 +18130,7 @@ fi
 if test $ac_cv_found_antlr = yes ; then
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: $antlr_version" >&5
 printf "%s\n" "$antlr_version" >&6; }
-  ANTLR="java antlr.Tool"
+  ANTLR="java -cp $ANTLR_HOME/antlr.jar antlr.Tool"
 else
   ANTLR=""
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: no" >&5

--- a/src/AST.hpp
+++ b/src/AST.hpp
@@ -116,7 +116,7 @@ namespace AST {
   union Status {
     int i;
     ASTNode *n;
-    Status() {}
+    Status() : n(0) {}
     Status(int ii) : i(ii) {}
     Status(ASTNode *nn) : n(nn) {}
   };

--- a/src/AST.nw
+++ b/src/AST.nw
@@ -1311,7 +1311,7 @@ $forwarddefs
   union Status {
     int i;
     ASTNode *n;
-    Status() {}
+    Status() : n(0) {}
     Status(int ii) : i(ii) {}
     Status(ASTNode *nn) : n(nn) {}
   };

--- a/src/ASTGRC.cpp
+++ b/src/ASTGRC.cpp
@@ -1,10 +1,10 @@
-#line 3233 "ASTGRC.nw"
+#line 3229 "ASTGRC.nw"
 #include <cstdio>
 #include "ASTGRC.hpp"
 
 namespace ASTGRC {
   
-#line 586 "ASTGRC.nw"
+#line 582 "ASTGRC.nw"
 GrcSynth::GrcSynth(Module *m, CompletionCodes &c)
   : module(m), code(c),
     surface_context(code.max() + 1),
@@ -35,19 +35,19 @@ GrcSynth::GrcSynth(Module *m, CompletionCodes &c)
     clone.sameVar(s);
   }
 }
-#line 3238 "ASTGRC.nw"
+#line 3234 "ASTGRC.nw"
   
-#line 743 "ASTGRC.nw"
+#line 739 "ASTGRC.nw"
 GrcWalker::GrcWalker(Context &c, GrcSynth &e)
     : context(c), environment(e), clone(e.clone) {}
-#line 748 "ASTGRC.nw"
+#line 744 "ASTGRC.nw"
 STNode *GrcWalker::stnode(const ASTNode &n) {
   assert(environment.ast2st.find(&n) != environment.ast2st.end() );
   return environment.ast2st[&n];
 }
-#line 3239 "ASTGRC.nw"
+#line 3235 "ASTGRC.nw"
   
-#line 831 "ASTGRC.nw"
+#line 827 "ASTGRC.nw"
 Status Surface::visit(Pause &s) {
   Enter *en = new Enter(stnode(s));
   assert(en->st);
@@ -55,14 +55,14 @@ Status Surface::visit(Pause &s) {
   context(0) = en;
   return Status();
 }
-#line 870 "ASTGRC.nw"
+#line 866 "ASTGRC.nw"
 Status Surface::visit(Exit &s) {
   assert(s.trap);
   context(0) = context(environment.code[s.trap]);
   push_onto(context(0), new Action(clone(&s)));
   return Status();
 }
-#line 955 "ASTGRC.nw"
+#line 951 "ASTGRC.nw"
 Status Surface::visit(IfThenElse &s) {
   Enter *en;
   assert(s.predicate);
@@ -74,7 +74,7 @@ Status Surface::visit(IfThenElse &s) {
   push_onto(context(0), en);
   return Status();
 }
-#line 1016 "ASTGRC.nw"
+#line 1012 "ASTGRC.nw"
 Status Surface::visit(StatementList &s) {
 
   for ( vector<Statement*>::reverse_iterator i = s.statements.rbegin() ;
@@ -86,14 +86,14 @@ Status Surface::visit(StatementList &s) {
   push_onto(context(0), new Enter(stnode(s)));
   return Status();
 }
-#line 1081 "ASTGRC.nw"
+#line 1077 "ASTGRC.nw"
 Status Surface::visit(Loop &s) {
   context(0) = synthesize(s.body);
   Enter *en = new Enter(stnode(s));
   push_onto(context(0), en);
   return Status();
 }
-#line 1131 "ASTGRC.nw"
+#line 1127 "ASTGRC.nw"
 Status Surface::visit(Every &s) {
 
   STNode *halt = stnode(s)->children[0]->children[0];
@@ -124,7 +124,7 @@ Status Surface::visit(Every &s) {
 
   return Status();
 }
-#line 1231 "ASTGRC.nw"
+#line 1227 "ASTGRC.nw"
 Status Surface::visit(Repeat &s) {
   context(0) = synthesize(s.body);
   assert(s.counter);
@@ -134,7 +134,7 @@ Status Surface::visit(Repeat &s) {
   push_onto(context(0), en);
   return Status();
 }
-#line 1301 "ASTGRC.nw"
+#line 1297 "ASTGRC.nw"
 Status Surface::visit(Suspend &s)
 {
   assert(s.body);
@@ -175,7 +175,7 @@ Status Surface::visit(Suspend &s)
   context(0) = start;
   return Status();
 }
-#line 1462 "ASTGRC.nw"
+#line 1458 "ASTGRC.nw"
 Status Surface::visit(Abort &s) {
   if (s.is_weak) throw IR::Error("weak abort.  Did the dismantler run?");
 
@@ -239,7 +239,7 @@ Status Surface::visit(Abort &s) {
 
   return Status();
 }
-#line 1652 "ASTGRC.nw"
+#line 1648 "ASTGRC.nw"
 Status Surface::visit(ParallelStatementList &s) {
   Sync *sync = new Sync(stnode(s));
   Fork *fork = new Fork(sync);
@@ -284,7 +284,7 @@ Status Surface::visit(ParallelStatementList &s) {
   push_onto(context(0), new Enter(stnode(s)));
   return Status();
 }
-#line 1810 "ASTGRC.nw"
+#line 1806 "ASTGRC.nw"
 Status Surface::visit(Trap &s) {
 
   assert(s.symbols);
@@ -346,7 +346,7 @@ Status Surface::visit(Trap &s) {
 
   return Status();
 }
-#line 1973 "ASTGRC.nw"
+#line 1969 "ASTGRC.nw"
 Status Surface::visit(Signal &s) {
   for ( SymbolTable::const_iterator i = s.symbols->begin() ;
         i != s.symbols->end() ; i++ ) {
@@ -366,7 +366,7 @@ Status Surface::visit(Signal &s) {
   }
   return Status();
 }
-#line 2042 "ASTGRC.nw"
+#line 2038 "ASTGRC.nw"
 Status Surface::visit(Var &s) {
   for ( SymbolTable::const_iterator i = s.symbols->begin() ;
 	i != s.symbols->end() ; i++ ) {
@@ -379,13 +379,13 @@ Status Surface::visit(Var &s) {
   context(0) = synthesize(s.body);
   return Status();
 }
-#line 3240 "ASTGRC.nw"
+#line 3236 "ASTGRC.nw"
   
-#line 847 "ASTGRC.nw"
+#line 843 "ASTGRC.nw"
 Status Depth::visit(Pause &s) {
   return Status();
 }
-#line 976 "ASTGRC.nw"
+#line 972 "ASTGRC.nw"
 Status Depth::visit(IfThenElse &s) {
   Switch *sw = new Switch(stnode(s));
   *sw >> ( (s.else_part != 0) ? recurse(s.else_part) : context(0))
@@ -393,7 +393,7 @@ Status Depth::visit(IfThenElse &s) {
   context(0) = sw;
   return Status();
 }
-#line 1036 "ASTGRC.nw"
+#line 1032 "ASTGRC.nw"
 Status Depth::visit(StatementList &s) {
   Switch *sw;
   if (!s.statements.empty()) {
@@ -413,7 +413,7 @@ Status Depth::visit(StatementList &s) {
   }
   return Status();
 }
-#line 1094 "ASTGRC.nw"
+#line 1090 "ASTGRC.nw"
 Status Depth::visit(Loop &s) {
   environment.surface_context.push(context);
   // Synthesize the surface
@@ -423,7 +423,7 @@ Status Depth::visit(Loop &s) {
   environment.surface_context.pop();
   return Status();
 }
-#line 1168 "ASTGRC.nw"
+#line 1164 "ASTGRC.nw"
 Status Depth::visit(Every &s) {
 
   Delay *d = dynamic_cast<Delay*>(s.predicate);
@@ -462,7 +462,7 @@ Status Depth::visit(Every &s) {
 
   return Status();
 }
-#line 1247 "ASTGRC.nw"
+#line 1243 "ASTGRC.nw"
 Status Depth::visit(Repeat &s) {
 
   // std::cerr<<"depth visit\n";
@@ -484,7 +484,7 @@ Status Depth::visit(Repeat &s) {
 
   return Status();
 }
-#line 1344 "ASTGRC.nw"
+#line 1340 "ASTGRC.nw"
 Status Depth::visit(Suspend &s) {
 
   assert(s.predicate);
@@ -542,7 +542,7 @@ Status Depth::visit(Suspend &s) {
   context(0) = swimm;
   return Status();
 }
-#line 1534 "ASTGRC.nw"
+#line 1530 "ASTGRC.nw"
 Status Depth::visit(Abort &s) {
   if (s.is_weak) throw IR::Error("weak abort.  Did the dismantler run?");
 
@@ -613,7 +613,7 @@ Status Depth::visit(Abort &s) {
 
   return Status();
 }
-#line 1703 "ASTGRC.nw"
+#line 1699 "ASTGRC.nw"
 Status Depth::visit(ParallelStatementList &s) {
   Sync *sync = new Sync(stnode(s));
   Fork *fork = new Fork(sync);
@@ -662,7 +662,7 @@ Status Depth::visit(ParallelStatementList &s) {
   push_onto(context(0), new Enter(stnode(s))); // hold
   return Status();
 }
-#line 1879 "ASTGRC.nw"
+#line 1875 "ASTGRC.nw"
 Status Depth::visit(Trap &s) {
 
   assert(s.symbols);
@@ -728,7 +728,7 @@ Status Depth::visit(Trap &s) {
   context(0) = topswitch;
   return Status();
 }
-#line 1995 "ASTGRC.nw"
+#line 1991 "ASTGRC.nw"
 Status Depth::visit(Signal &s) {
   for ( SymbolTable::const_iterator i = s.symbols->begin() ;
         i != s.symbols->end() ; i++ ) {
@@ -747,7 +747,7 @@ Status Depth::visit(Signal &s) {
   }
   return Status();
 }
-#line 2057 "ASTGRC.nw"
+#line 2053 "ASTGRC.nw"
 Status Depth::visit(Var &s) {
   for ( SymbolTable::const_iterator i = s.symbols->begin() ;
 	i != s.symbols->end() ; i++ ) {
@@ -760,20 +760,20 @@ Status Depth::visit(Var &s) {
   context(0) = synthesize(s.body);
   return Status();
 }
-#line 3241 "ASTGRC.nw"
+#line 3237 "ASTGRC.nw"
   
-#line 778 "ASTGRC.nw"
+#line 774 "ASTGRC.nw"
 void SelTree::setNode(const ASTNode &n, STNode *sn) {
   assert(sn);
   environment.ast2st[&n] = sn;
 }
-#line 817 "ASTGRC.nw"
+#line 813 "ASTGRC.nw"
 Status SelTree::visit(Pause &s){
   STleaf *leaf = new STleaf();
   setNode(s, leaf);
   return Status(leaf);
 }
-#line 937 "ASTGRC.nw"
+#line 933 "ASTGRC.nw"
 Status SelTree::visit(IfThenElse &s) {  
   STexcl *ite = new STexcl();
   setNode(s, ite);
@@ -783,7 +783,7 @@ Status SelTree::visit(IfThenElse &s) {
 
   return Status(ite);
 }
-#line 996 "ASTGRC.nw"
+#line 992 "ASTGRC.nw"
 Status  SelTree::visit(StatementList &s)
 {
   STexcl *excl = new STexcl();
@@ -799,14 +799,14 @@ Status  SelTree::visit(StatementList &s)
 }
 
 
-#line 1068 "ASTGRC.nw"
+#line 1064 "ASTGRC.nw"
 Status SelTree::visit(Loop &s) {
   STref *lp = new STref();
   setNode(s, lp);
   *lp >> synthesize(s.body);
   return Status(lp);
 }
-#line 1112 "ASTGRC.nw"
+#line 1108 "ASTGRC.nw"
 Status SelTree::visit(Every &s) {
 
   STref *ab = new STref(); ab->setabort(); setNode(s, ab);
@@ -819,14 +819,14 @@ Status SelTree::visit(Every &s) {
   return Status(ab);
 
 }
-#line 1218 "ASTGRC.nw"
+#line 1214 "ASTGRC.nw"
 Status SelTree::visit(Repeat &s) {
   STref *lp = new STref();
   setNode(s, lp);
   *lp >> synthesize(s.body);
   return Status(lp);
 }
-#line 1282 "ASTGRC.nw"
+#line 1278 "ASTGRC.nw"
 Status SelTree::visit(Suspend &s)
 {
   STexcl *ex = new STexcl();
@@ -843,7 +843,7 @@ Status SelTree::visit(Suspend &s)
   setNode(s, ex);
   return Status(ex);
 }
-#line 1424 "ASTGRC.nw"
+#line 1420 "ASTGRC.nw"
 Status SelTree::visit(Abort &s) {
 
   // The selection tree for the body of the abort:
@@ -874,7 +874,7 @@ Status SelTree::visit(Abort &s) {
   setNode(s, exclusive);
   return Status(exclusive);
 }
-#line 1627 "ASTGRC.nw"
+#line 1623 "ASTGRC.nw"
 Status SelTree::visit(ParallelStatementList &s)
 {
   STpar *par = new STpar();
@@ -893,7 +893,7 @@ Status SelTree::visit(ParallelStatementList &s)
 
   return Status(par);
 }
-#line 1766 "ASTGRC.nw"
+#line 1762 "ASTGRC.nw"
 Status SelTree::visit(Trap &s) {
 
   // Create the topmost exclusive node
@@ -929,21 +929,21 @@ Status SelTree::visit(Trap &s) {
   setNode(s, exclusive);
   return Status(exclusive);  
 }
-#line 1965 "ASTGRC.nw"
+#line 1961 "ASTGRC.nw"
 Status SelTree::visit(Signal &s) {
   STNode *st = new STref();
   *st >> synthesize(s.body);
   return Status(st);
 }
-#line 2034 "ASTGRC.nw"
+#line 2030 "ASTGRC.nw"
 Status SelTree::visit(Var &s) {
   STNode *st = new STref();
   *st >> synthesize(s.body);
   return Status(st);
 }
-#line 3242 "ASTGRC.nw"
+#line 3238 "ASTGRC.nw"
   
-#line 2985 "ASTGRC.nw"
+#line 2981 "ASTGRC.nw"
 void Dependencies::compute(GRCNode *root)
 {
   assert(root);
@@ -965,7 +965,7 @@ void Dependencies::compute(GRCNode *root)
     }
   }
 }
-#line 3015 "ASTGRC.nw"
+#line 3011 "ASTGRC.nw"
 void Dependencies::dfs(GRCNode *n)
 {
   if (!n || visited.find(n) != visited.end() ) return;
@@ -978,14 +978,14 @@ void Dependencies::dfs(GRCNode *n)
   for (vector<GRCNode*>::const_iterator i = n->successors.begin() ;
        i < n->successors.end() ; i++ ) dfs(*i);  
 }
-#line 3038 "ASTGRC.nw"
+#line 3034 "ASTGRC.nw"
 Status Dependencies::visit(Action &act)
 {
   assert(act.body);
   act.body->welcome(*this);
   return Status();
 }
-#line 3163 "ASTGRC.nw"
+#line 3159 "ASTGRC.nw"
 Status Dependencies::visit(Sync &s)
 {
   for ( vector<GRCNode*>::const_iterator i = s.predecessors.begin() ;
@@ -996,9 +996,9 @@ Status Dependencies::visit(Sync &s)
   }
   return Status();
 }
-#line 3243 "ASTGRC.nw"
+#line 3239 "ASTGRC.nw"
   
-#line 2165 "ASTGRC.nw"
+#line 2161 "ASTGRC.nw"
 RecursiveSynth::RecursiveSynth(Module *m, CompletionCodes &c)
   : module(m), code(c), context(code.max() + 1) {
   assert(m);
@@ -1024,7 +1024,7 @@ RecursiveSynth::RecursiveSynth(Module *m, CompletionCodes &c)
     clone.sameVar(s);
   }
 }
-#line 2197 "ASTGRC.nw"
+#line 2193 "ASTGRC.nw"
 GRCgraph *RecursiveSynth::synthesize()
 {
   assert(module->body);
@@ -1072,7 +1072,7 @@ GRCgraph *RecursiveSynth::synthesize()
 
   return result;
 }
-#line 2264 "ASTGRC.nw"
+#line 2260 "ASTGRC.nw"
 void RecursiveSynth::visit(GRCNode *n)
 {
   assert(n);
@@ -1087,7 +1087,7 @@ void RecursiveSynth::visit(GRCNode *n)
 
   visiting[n] = false;
 }
-#line 2287 "ASTGRC.nw"
+#line 2283 "ASTGRC.nw"
 Status RecursiveSynth::visit(Pause &s)
 {
   stnode = new STleaf();
@@ -1099,7 +1099,7 @@ Status RecursiveSynth::visit(Pause &s)
 
   return Status();
 }
-#line 2307 "ASTGRC.nw"
+#line 2303 "ASTGRC.nw"
 Status RecursiveSynth::visit(Exit &s)
 {
   assert(s.trap);
@@ -1109,7 +1109,7 @@ Status RecursiveSynth::visit(Exit &s)
   depth = context(0);
   return Status();
 }
-#line 2325 "ASTGRC.nw"
+#line 2321 "ASTGRC.nw"
 Status RecursiveSynth::visit(Emit &s)
 {
   stnode = new STref();
@@ -1118,7 +1118,7 @@ Status RecursiveSynth::visit(Emit &s)
   depth = context(0);
   return Status();
 }
-#line 2342 "ASTGRC.nw"
+#line 2338 "ASTGRC.nw"
 Status RecursiveSynth::visit(Assign &s)
 {
   stnode = new STref();
@@ -1127,7 +1127,7 @@ Status RecursiveSynth::visit(Assign &s)
   depth = context(0);
   return Status();
 }
-#line 2359 "ASTGRC.nw"
+#line 2355 "ASTGRC.nw"
 Status RecursiveSynth::visit(IfThenElse &s)
 {  
   if (s.then_part) {
@@ -1161,7 +1161,7 @@ Status RecursiveSynth::visit(IfThenElse &s)
 
   return Status();
 }
-#line 2401 "ASTGRC.nw"
+#line 2397 "ASTGRC.nw"
 Status RecursiveSynth::visit(StatementList &s)
 {
   if ( s.statements.empty() ) {
@@ -1187,7 +1187,7 @@ Status RecursiveSynth::visit(StatementList &s)
   run_before(surface, new Enter(stnode));
   return Status();
 }
-#line 2443 "ASTGRC.nw"
+#line 2439 "ASTGRC.nw"
 Status RecursiveSynth::visit(Loop &s)
 {
   STref *lp = new STref();
@@ -1206,7 +1206,7 @@ Status RecursiveSynth::visit(Loop &s)
   run_before(surface, new Enter(lp));
   return Status();
 }
-#line 2470 "ASTGRC.nw"
+#line 2466 "ASTGRC.nw"
 Status RecursiveSynth::visit(Every &s)
 {
   STref *stroot = new STref();
@@ -1262,7 +1262,7 @@ Status RecursiveSynth::visit(Every &s)
   stnode = stroot;
   return Status();
 }
-#line 2534 "ASTGRC.nw"
+#line 2530 "ASTGRC.nw"
 Status RecursiveSynth::visit(Repeat &s)
 {
   STref *stroot = new STref();
@@ -1285,7 +1285,7 @@ Status RecursiveSynth::visit(Repeat &s)
   run_before(surface, new Enter(stroot));
   return Status();
 }
-#line 2566 "ASTGRC.nw"
+#line 2562 "ASTGRC.nw"
 Status RecursiveSynth::visit(Suspend &s)
 {
   synthesize(s.body);
@@ -1352,7 +1352,7 @@ Status RecursiveSynth::visit(Suspend &s)
 
   return Status();
 }
-#line 2641 "ASTGRC.nw"
+#line 2637 "ASTGRC.nw"
 Status RecursiveSynth::visit(Abort &s)
 {
   if (s.is_weak) throw IR::Error("weak abort.  Did the dismantler run?");
@@ -1434,7 +1434,7 @@ Status RecursiveSynth::visit(Abort &s)
 
   return Status();
 }
-#line 2731 "ASTGRC.nw"
+#line 2727 "ASTGRC.nw"
 Status RecursiveSynth::visit(ParallelStatementList &s)
 {
   STpar *stroot = new STpar();
@@ -1500,7 +1500,7 @@ Status RecursiveSynth::visit(ParallelStatementList &s)
   stnode = stroot;
   return Status();
 }
-#line 2805 "ASTGRC.nw"
+#line 2801 "ASTGRC.nw"
 Status RecursiveSynth::visit(Trap &s)
 {
   assert(s.body);
@@ -1570,7 +1570,7 @@ Status RecursiveSynth::visit(Trap &s)
   stnode = stroot;
   return Status();
 }
-#line 2884 "ASTGRC.nw"
+#line 2880 "ASTGRC.nw"
 Status RecursiveSynth::visit(Signal &s)
 {
   for ( SymbolTable::const_iterator i = s.symbols->begin() ;
@@ -1606,7 +1606,7 @@ Status RecursiveSynth::visit(Var &s)
   synthesize(s.body);
   return Status();
 }
-#line 2928 "ASTGRC.nw"
+#line 2924 "ASTGRC.nw"
 Status RecursiveSynth::visit(ProcedureCall &s)
 {
   stnode = new STref();
@@ -1615,7 +1615,7 @@ Status RecursiveSynth::visit(ProcedureCall &s)
   depth = context(0);
   return Status();
 }
-#line 2947 "ASTGRC.nw"
+#line 2943 "ASTGRC.nw"
 Status RecursiveSynth::visit(Exec &s)
 {
   stnode = new STref();
@@ -1623,5 +1623,5 @@ Status RecursiveSynth::visit(Exec &s)
   depth = context(0);
   return Status();
 }
-#line 3244 "ASTGRC.nw"
+#line 3240 "ASTGRC.nw"
 }

--- a/src/ASTGRC.hpp
+++ b/src/ASTGRC.hpp
@@ -1,4 +1,4 @@
-#line 3197 "ASTGRC.nw"
+#line 3193 "ASTGRC.nw"
 #ifndef _ASTGRC_HPP
 #  define _ASTGRC_HPP
 
@@ -145,7 +145,7 @@ Status visit(Trap &s) {
 #line 47 "ASTGRC.nw"
 };
 
-#line 3217 "ASTGRC.nw"
+#line 3213 "ASTGRC.nw"
   
 #line 211 "ASTGRC.nw"
 class Cloner : public Visitor {
@@ -167,9 +167,7 @@ SignalSymbol *cloneLocalSignal(SignalSymbol *s, SymbolTable *st) {
   string name = s->name;
   int next = 1;
   while (st->contains(name)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    name = s->name + '_' + buf;
+    name = s->name + '_' + std::to_string(next++);
   }
   SignalSymbol::kinds kind =
     (s->kind == SignalSymbol::Trap) ? SignalSymbol::Trap : SignalSymbol::Local;
@@ -189,22 +187,22 @@ SignalSymbol *cloneLocalSignal(SignalSymbol *s, SymbolTable *st) {
   newsig[s] = result;
   return result;
 }
-#line 385 "ASTGRC.nw"
+#line 383 "ASTGRC.nw"
 void sameSig(SignalSymbol *s) {
   assert(s);
   assert(newsig.find(s) == newsig.end());
   newsig[s] = s;
 }
-#line 395 "ASTGRC.nw"
+#line 393 "ASTGRC.nw"
 void clearSig(SignalSymbol *orig) {
   assert(orig);
   map<SignalSymbol*, SignalSymbol*>::iterator i = newsig.find(orig);
   assert(i != newsig.end());
   newsig.erase(i);
 }
-#line 424 "ASTGRC.nw"
+#line 422 "ASTGRC.nw"
 map<VariableSymbol*, VariableSymbol*> newvar;
-#line 428 "ASTGRC.nw"
+#line 426 "ASTGRC.nw"
 VariableSymbol *hoistLocalVariable(VariableSymbol *s, SymbolTable *st) {
   assert(s);
   assert(newvar.find(s) == newvar.end()); // should not be remapped yet
@@ -215,9 +213,7 @@ VariableSymbol *hoistLocalVariable(VariableSymbol *s, SymbolTable *st) {
   string name = s->name;
   int next = 1;
   while (st->contains(name)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    name = s->name + '_' + buf;
+    name = s->name + '_' + std::to_string(next++);
   }
 
   VariableSymbol *result =
@@ -226,7 +222,7 @@ VariableSymbol *hoistLocalVariable(VariableSymbol *s, SymbolTable *st) {
   newvar[s] = result;
   return result;
 }
-#line 452 "ASTGRC.nw"
+#line 448 "ASTGRC.nw"
 void sameVar(VariableSymbol *s) {
   assert(s);
   assert(newvar.find(s) == newvar.end());
@@ -319,12 +315,12 @@ Status visit(BuiltinFunctionSymbol &s) { return &s; }
 Status visit(Counter &s) { return &s; }
 #line 343 "ASTGRC.nw"
 map<SignalSymbol*, SignalSymbol*> newsig;
-#line 412 "ASTGRC.nw"
+#line 410 "ASTGRC.nw"
 Status visit(SignalSymbol &s) {
   assert(newsig.find(&s) != newsig.end()); // should be there
   return newsig[&s];
 }
-#line 462 "ASTGRC.nw"
+#line 458 "ASTGRC.nw"
 Status visit(VariableSymbol &s) {
   assert(newvar.find(&s) != newvar.end()); // should be there
   return newvar[&s];
@@ -332,9 +328,9 @@ Status visit(VariableSymbol &s) {
 #line 233 "ASTGRC.nw"
 };
 
-#line 3219 "ASTGRC.nw"
+#line 3215 "ASTGRC.nw"
   
-#line 511 "ASTGRC.nw"
+#line 507 "ASTGRC.nw"
 struct Context {
   int size;
   std::stack<GRCNode**> continuations;
@@ -366,9 +362,9 @@ struct Context {
     return continuations.top()[k];
   }
 };
-#line 3220 "ASTGRC.nw"
+#line 3216 "ASTGRC.nw"
   
-#line 710 "ASTGRC.nw"
+#line 706 "ASTGRC.nw"
 class GrcWalker : public Visitor {
 protected:
   Context &context;
@@ -399,44 +395,90 @@ public:
 
   STNode *stnode(const ASTNode &);
 };
-#line 3221 "ASTGRC.nw"
+#line 3217 "ASTGRC.nw"
   
-#line 785 "ASTGRC.nw"
+#line 781 "ASTGRC.nw"
 class Surface : public GrcWalker {
 public:
   Surface(Context &c, GrcSynth &e) : GrcWalker(c, e) {}
   
-#line 827 "ASTGRC.nw"
+#line 823 "ASTGRC.nw"
 Status visit(Pause &);
-#line 866 "ASTGRC.nw"
+#line 862 "ASTGRC.nw"
 Status visit(Exit &);
-#line 893 "ASTGRC.nw"
+#line 889 "ASTGRC.nw"
 Status visit(Emit &s) {
   push_onto(context(0), new Action(clone(&s)));
   return Status();
 }
-#line 916 "ASTGRC.nw"
+#line 912 "ASTGRC.nw"
 Status visit(Assign &s) {
   Action *a = new Action(clone(&s));
   *a >> context(0);
   context(0) = a;
   return Status();
 }
-#line 951 "ASTGRC.nw"
+#line 947 "ASTGRC.nw"
 Status visit(IfThenElse &);
-#line 1012 "ASTGRC.nw"
+#line 1008 "ASTGRC.nw"
 Status visit(StatementList &);
-#line 1077 "ASTGRC.nw"
+#line 1073 "ASTGRC.nw"
 Status visit(Loop &);
-#line 1127 "ASTGRC.nw"
+#line 1123 "ASTGRC.nw"
 Status visit(Every &);
-#line 1227 "ASTGRC.nw"
+#line 1223 "ASTGRC.nw"
+Status visit(Repeat &);
+#line 1404 "ASTGRC.nw"
+Status visit(Suspend &);
+#line 1607 "ASTGRC.nw"
+Status visit(Abort &);
+#line 1644 "ASTGRC.nw"
+Status visit(ParallelStatementList &);
+#line 1947 "ASTGRC.nw"
+Status visit(Trap &);
+#line 2016 "ASTGRC.nw"
+Status visit(Signal &);
+#line 2072 "ASTGRC.nw"
+Status visit(Var &);
+#line 2088 "ASTGRC.nw"
+Status visit(Exec &) { return Status(); }
+#line 2102 "ASTGRC.nw"
+Status visit(ProcedureCall &s) {
+  push_onto(context(0), new Action(clone(&s)));
+  return Status();
+}
+#line 785 "ASTGRC.nw"
+};
+#line 3218 "ASTGRC.nw"
+  
+#line 789 "ASTGRC.nw"
+class Depth : public GrcWalker {
+public:
+  Depth(Context &c, GrcSynth &e) : GrcWalker(c, e) {}
+  
+#line 839 "ASTGRC.nw"
+Status visit(Pause &);
+#line 875 "ASTGRC.nw"
+Status visit(Exit &) { return Status(); }
+#line 896 "ASTGRC.nw"
+Status visit(Emit &) { return Status(); }
+#line 921 "ASTGRC.nw"
+Status visit(Assign &) { return Status(); }
+#line 968 "ASTGRC.nw"
+Status visit(IfThenElse &);
+#line 1026 "ASTGRC.nw"
+Status visit(StatementList &);
+#line 1086 "ASTGRC.nw"
+Status visit(Loop &);
+#line 1160 "ASTGRC.nw"
+Status visit(Every &);
+#line 1239 "ASTGRC.nw"
 Status visit(Repeat &);
 #line 1408 "ASTGRC.nw"
 Status visit(Suspend &);
 #line 1611 "ASTGRC.nw"
 Status visit(Abort &);
-#line 1648 "ASTGRC.nw"
+#line 1695 "ASTGRC.nw"
 Status visit(ParallelStatementList &);
 #line 1951 "ASTGRC.nw"
 Status visit(Trap &);
@@ -446,59 +488,13 @@ Status visit(Signal &);
 Status visit(Var &);
 #line 2092 "ASTGRC.nw"
 Status visit(Exec &) { return Status(); }
-#line 2106 "ASTGRC.nw"
-Status visit(ProcedureCall &s) {
-  push_onto(context(0), new Action(clone(&s)));
-  return Status();
-}
-#line 789 "ASTGRC.nw"
-};
-#line 3222 "ASTGRC.nw"
-  
-#line 793 "ASTGRC.nw"
-class Depth : public GrcWalker {
-public:
-  Depth(Context &c, GrcSynth &e) : GrcWalker(c, e) {}
-  
-#line 843 "ASTGRC.nw"
-Status visit(Pause &);
-#line 879 "ASTGRC.nw"
-Status visit(Exit &) { return Status(); }
-#line 900 "ASTGRC.nw"
-Status visit(Emit &) { return Status(); }
-#line 925 "ASTGRC.nw"
-Status visit(Assign &) { return Status(); }
-#line 972 "ASTGRC.nw"
-Status visit(IfThenElse &);
-#line 1030 "ASTGRC.nw"
-Status visit(StatementList &);
-#line 1090 "ASTGRC.nw"
-Status visit(Loop &);
-#line 1164 "ASTGRC.nw"
-Status visit(Every &);
-#line 1243 "ASTGRC.nw"
-Status visit(Repeat &);
-#line 1412 "ASTGRC.nw"
-Status visit(Suspend &);
-#line 1615 "ASTGRC.nw"
-Status visit(Abort &);
-#line 1699 "ASTGRC.nw"
-Status visit(ParallelStatementList &);
-#line 1955 "ASTGRC.nw"
-Status visit(Trap &);
-#line 2024 "ASTGRC.nw"
-Status visit(Signal &);
-#line 2080 "ASTGRC.nw"
-Status visit(Var &);
-#line 2096 "ASTGRC.nw"
-Status visit(Exec &) { return Status(); }
-#line 2113 "ASTGRC.nw"
+#line 2109 "ASTGRC.nw"
 Status visit(ProcedureCall &) { return Status(); }
-#line 797 "ASTGRC.nw"
+#line 793 "ASTGRC.nw"
 };
-#line 3223 "ASTGRC.nw"
+#line 3219 "ASTGRC.nw"
   
-#line 758 "ASTGRC.nw"
+#line 754 "ASTGRC.nw"
 class SelTree : public Visitor {
 protected:
   GrcSynth &environment;
@@ -515,51 +511,51 @@ public:
   void setNode(const ASTNode &, STNode *);
     
   
-#line 813 "ASTGRC.nw"
+#line 809 "ASTGRC.nw"
 Status visit(Pause &);
-#line 860 "ASTGRC.nw"
+#line 856 "ASTGRC.nw"
 Status visit(Exit &s) {
   return Status(new STref());
 }
-#line 885 "ASTGRC.nw"
+#line 881 "ASTGRC.nw"
 Status visit(Emit &) {
   return Status(new STref());
 }
-#line 910 "ASTGRC.nw"
+#line 906 "ASTGRC.nw"
 Status visit(Assign &s) {
   return Status(new STref());
 }
-#line 933 "ASTGRC.nw"
+#line 929 "ASTGRC.nw"
 Status visit(IfThenElse &);
-#line 992 "ASTGRC.nw"
+#line 988 "ASTGRC.nw"
 Status visit(StatementList &s);
-#line 1064 "ASTGRC.nw"
+#line 1060 "ASTGRC.nw"
 Status visit(Loop &s);
-#line 1108 "ASTGRC.nw"
+#line 1104 "ASTGRC.nw"
 Status visit(Every &);
-#line 1214 "ASTGRC.nw"
+#line 1210 "ASTGRC.nw"
 Status visit(Repeat &);
-#line 1404 "ASTGRC.nw"
+#line 1400 "ASTGRC.nw"
 Status visit(Suspend &);
-#line 1607 "ASTGRC.nw"
+#line 1603 "ASTGRC.nw"
 Status visit(Abort &);
-#line 1623 "ASTGRC.nw"
+#line 1619 "ASTGRC.nw"
 Status visit(ParallelStatementList &);
-#line 1947 "ASTGRC.nw"
+#line 1943 "ASTGRC.nw"
 Status visit(Trap &);
-#line 2016 "ASTGRC.nw"
+#line 2012 "ASTGRC.nw"
 Status visit(Signal &);
-#line 2072 "ASTGRC.nw"
+#line 2068 "ASTGRC.nw"
 Status visit(Var &);
-#line 2088 "ASTGRC.nw"
+#line 2084 "ASTGRC.nw"
 Status visit(Exec &) { return Status(new STref()); }
-#line 2102 "ASTGRC.nw"
+#line 2098 "ASTGRC.nw"
 Status visit(ProcedureCall &) { return Status(new STref()); }
-#line 774 "ASTGRC.nw"
+#line 770 "ASTGRC.nw"
 };
-#line 3224 "ASTGRC.nw"
+#line 3220 "ASTGRC.nw"
   
-#line 555 "ASTGRC.nw"
+#line 551 "ASTGRC.nw"
 struct GrcSynth {
   Module *module;
   CompletionCodes &code;
@@ -580,9 +576,9 @@ struct GrcSynth {
   BuiltinConstantSymbol *true_symbol;
 
   
-#line 582 "ASTGRC.nw"
+#line 578 "ASTGRC.nw"
 GrcSynth(Module *, CompletionCodes &);
-#line 623 "ASTGRC.nw"
+#line 619 "ASTGRC.nw"
 GRCgraph *synthesize()
 {
   assert(module->body);
@@ -647,11 +643,11 @@ GRCgraph *synthesize()
 
   return result;
 }
-#line 575 "ASTGRC.nw"
+#line 571 "ASTGRC.nw"
 };
-#line 3225 "ASTGRC.nw"
+#line 3221 "ASTGRC.nw"
   
-#line 2122 "ASTGRC.nw"
+#line 2118 "ASTGRC.nw"
 class RecursiveSynth : public Visitor {
 public:
   Module *module;
@@ -686,53 +682,53 @@ public:
   static void run_before(GRCNode *& b, GRCNode *n) { *n >> b; b = n; }
 
   
-#line 2161 "ASTGRC.nw"
+#line 2157 "ASTGRC.nw"
 RecursiveSynth(Module *, CompletionCodes &);
-#line 2193 "ASTGRC.nw"
+#line 2189 "ASTGRC.nw"
 GRCgraph *synthesize();
-#line 2259 "ASTGRC.nw"
+#line 2255 "ASTGRC.nw"
 map<GRCNode *, bool> visiting;
 void visit(GRCNode *);
-#line 2283 "ASTGRC.nw"
+#line 2279 "ASTGRC.nw"
 Status visit(Pause &);
-#line 2303 "ASTGRC.nw"
+#line 2299 "ASTGRC.nw"
 Status visit(Exit &);
-#line 2321 "ASTGRC.nw"
+#line 2317 "ASTGRC.nw"
 Status visit(Emit &);
-#line 2338 "ASTGRC.nw"
+#line 2334 "ASTGRC.nw"
 Status visit(Assign &);
-#line 2355 "ASTGRC.nw"
+#line 2351 "ASTGRC.nw"
 Status visit(IfThenElse &);
-#line 2397 "ASTGRC.nw"
+#line 2393 "ASTGRC.nw"
 Status visit(StatementList &);
-#line 2439 "ASTGRC.nw"
+#line 2435 "ASTGRC.nw"
 Status visit(Loop &);
-#line 2466 "ASTGRC.nw"
+#line 2462 "ASTGRC.nw"
 Status visit(Every &);
-#line 2530 "ASTGRC.nw"
+#line 2526 "ASTGRC.nw"
 Status visit(Repeat &);
-#line 2562 "ASTGRC.nw"
+#line 2558 "ASTGRC.nw"
 Status visit(Suspend &);
-#line 2637 "ASTGRC.nw"
+#line 2633 "ASTGRC.nw"
 Status visit(Abort &);
-#line 2727 "ASTGRC.nw"
+#line 2723 "ASTGRC.nw"
 Status visit(ParallelStatementList &);
-#line 2801 "ASTGRC.nw"
+#line 2797 "ASTGRC.nw"
 Status visit(Trap &);
-#line 2879 "ASTGRC.nw"
+#line 2875 "ASTGRC.nw"
 Status visit(Signal &);
 Status visit(Var &);
-#line 2924 "ASTGRC.nw"
+#line 2920 "ASTGRC.nw"
 Status visit(ProcedureCall &);
-#line 2943 "ASTGRC.nw"
+#line 2939 "ASTGRC.nw"
 Status visit(Exec &);
-#line 2156 "ASTGRC.nw"
+#line 2152 "ASTGRC.nw"
   virtual ~RecursiveSynth() {}
 };
 
-#line 3227 "ASTGRC.nw"
+#line 3223 "ASTGRC.nw"
   
-#line 2963 "ASTGRC.nw"
+#line 2959 "ASTGRC.nw"
 class Dependencies : public Visitor {
 protected:
   set<GRCNode *> visited;
@@ -747,45 +743,45 @@ public:
   map<SignalSymbol *, SignalNodes> dependencies;
 
   
-#line 3030 "ASTGRC.nw"
+#line 3026 "ASTGRC.nw"
 void dfs(GRCNode *);
-#line 3047 "ASTGRC.nw"
+#line 3043 "ASTGRC.nw"
 Status visit(Action &);
-#line 3051 "ASTGRC.nw"
+#line 3047 "ASTGRC.nw"
 Status visit(Emit &e) {
   dependencies[e.signal].writers.insert(current);
   if (e.value) e.value->welcome(*this);
   return Status();
 }
-#line 3059 "ASTGRC.nw"
+#line 3055 "ASTGRC.nw"
 Status visit(Exit &e) {
   dependencies[e.trap].writers.insert(current);
   if (e.value) e.value->welcome(*this);
   return Status();
 }
-#line 3067 "ASTGRC.nw"
+#line 3063 "ASTGRC.nw"
 Status visit(Assign &a) {
   a.value->welcome(*this);
   return Status();
 }
-#line 3074 "ASTGRC.nw"
+#line 3070 "ASTGRC.nw"
 Status visit(ProcedureCall &c) {
   for ( vector<Expression*>::const_iterator i = c.value_args.begin() ;
         i != c.value_args.end() ; i++ )
     (*i)->welcome(*this);
   return Status();
 }
-#line 3085 "ASTGRC.nw"
+#line 3081 "ASTGRC.nw"
 Status visit(Pause &) { return Status(); }
 Status visit(StartCounter &) { return Status(); }
-#line 3094 "ASTGRC.nw"
+#line 3090 "ASTGRC.nw"
 Status visit(DefineSignal &d) {
   dependencies[d.signal].writers.insert(current);
   return Status();
 }
-#line 3105 "ASTGRC.nw"
+#line 3101 "ASTGRC.nw"
 Status visit(Test &t) { t.predicate->welcome(*this); return Status(); }
-#line 3111 "ASTGRC.nw"
+#line 3107 "ASTGRC.nw"
 Status visit(LoadSignalExpression &e) {
   dependencies[e.signal].readers.insert(current);
   return Status();
@@ -823,12 +819,12 @@ Status visit(FunctionCall &c) {
     (*i)->welcome(*this);
   return Status();
 }
-#line 3153 "ASTGRC.nw"
+#line 3149 "ASTGRC.nw"
 Status visit(Literal &) { return Status(); }
 Status visit(LoadVariableExpression &) { return Status(); }
-#line 3176 "ASTGRC.nw"
+#line 3172 "ASTGRC.nw"
 Status visit(Sync &);
-#line 3184 "ASTGRC.nw"
+#line 3180 "ASTGRC.nw"
 Status visit(EnterGRC &) { return Status(); }
 Status visit(ExitGRC &) { return Status(); }
 Status visit(Nop &) { return Status(); }
@@ -837,12 +833,12 @@ Status visit(STSuspend &) { return Status(); }
 Status visit(Fork &) { return Status(); }
 Status visit(Terminate &) { return Status(); }
 Status visit(Enter &) { return Status(); }
-#line 2977 "ASTGRC.nw"
+#line 2973 "ASTGRC.nw"
   Dependencies() {}
   virtual ~Dependencies() {}
 
   static void compute(GRCNode *);
 };
-#line 3228 "ASTGRC.nw"
+#line 3224 "ASTGRC.nw"
 }
 #endif

--- a/src/ASTGRC.nw
+++ b/src/ASTGRC.nw
@@ -355,9 +355,7 @@ SignalSymbol *cloneLocalSignal(SignalSymbol *s, SymbolTable *st) {
   string name = s->name;
   int next = 1;
   while (st->contains(name)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    name = s->name + '_' + buf;
+    name = s->name + '_' + std::to_string(next++);
   }
   SignalSymbol::kinds kind =
     (s->kind == SignalSymbol::Trap) ? SignalSymbol::Trap : SignalSymbol::Local;
@@ -435,9 +433,7 @@ VariableSymbol *hoistLocalVariable(VariableSymbol *s, SymbolTable *st) {
   string name = s->name;
   int next = 1;
   while (st->contains(name)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    name = s->name + '_' + buf;
+    name = s->name + '_' + std::to_string(next++);
   }
 
   VariableSymbol *result =

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -21,13 +21,13 @@ Printer::Printer(std::ostream &o, Module &m, bool three_val)
   // Note: float and double aren't in this list because they are equivalent
   // to Esterel's types of the same name
 
-  char *keywords[] = {
+  const char *keywords[] = {
     "int", "break", "char", "continue", "if", "else",
     "struct", "for", "auto", "do", "extern", "while", "register", "switch",
     "static", "case", "goto", "default", "return", "entry", "sizeof", NULL
   };
 
-  for (char **k = keywords ; *k != NULL ; k++) identifiers.insert(*k);
+  for (const char **k = keywords ; *k != NULL ; k++) identifiers.insert(*k);
 }
 #line 109 "CPrinter.nw"
 string Printer::uniqueID(string name)
@@ -701,7 +701,7 @@ void Printer::printDeclarations(string basename)
   for ( vector<Counter*>::const_iterator i = m.counters.begin() ;
 	i != m.counters.end() ; i++ ) {
     char buf[15];
-    sprintf(buf, "_counter_%d", i-m.counters.begin() );
+    sprintf(buf, "_counter_%d", static_cast<unsigned int>(i-m.counters.begin()) );
     string var = uniqueID(buf);
     counterVar[*i] = var;
     o << "static int " << var << ";\n";

--- a/src/CPrinter.cpp
+++ b/src/CPrinter.cpp
@@ -1,4 +1,4 @@
-#line 1665 "CPrinter.nw"
+#line 1651 "CPrinter.nw"
 #include "CPrinter.hpp"
 #include <stdio.h>
 
@@ -34,18 +34,15 @@ string Printer::uniqueID(string name)
 {
   string newname = name;
 
-  char buf[10];
   int version = 1;
-
   while (contains(identifiers, newname)) {
-    sprintf(buf, "%d", version++);
-    newname = name + '_' + buf;
+    newname = name + '_' + std::to_string(version++);
   }
   
   identifiers.insert(newname);
   return newname;
 }
-#line 193 "CPrinter.nw"
+#line 190 "CPrinter.nw"
 Status Printer::visit(Enter &e)
 {
   STexcl *exclusive = 0;
@@ -83,7 +80,7 @@ Status Printer::visit(Enter &e)
 
   return Status();
 }
-#line 250 "CPrinter.nw"
+#line 247 "CPrinter.nw"
 Status Printer::visit(Terminate &t)
 {
   // If we have something other than a single data successor or it is not
@@ -100,7 +97,7 @@ Status Printer::visit(Terminate &t)
     o << terminationVar[s] << " &= -(1 << " << t.code << ")";
   return Status();
 }
-#line 317 "CPrinter.nw"
+#line 314 "CPrinter.nw"
 Status Printer::visit(Emit &e)
 {
   assert(e.signal);
@@ -125,7 +122,7 @@ Status Printer::visit(Emit &e)
   if (e.signal->type) o << ")";
   return Status();
 }
-#line 344 "CPrinter.nw"
+#line 341 "CPrinter.nw"
 Status Printer::visit(Exit &e)
 {
   assert(e.trap);
@@ -139,7 +136,7 @@ Status Printer::visit(Exit &e)
   o << presenceVar[e.trap] << " = 1";
   return Status();
 }
-#line 421 "CPrinter.nw"
+#line 418 "CPrinter.nw"
 Status Printer::visit(StartCounter &s)
 {
   assert(s.counter);
@@ -148,7 +145,7 @@ Status Printer::visit(StartCounter &s)
   printExpr(s.count);
   return Status();
 }
-#line 441 "CPrinter.nw"
+#line 438 "CPrinter.nw"
 Status Printer::visit(CheckCounter &s)
 {
   assert(s.counter);
@@ -165,7 +162,7 @@ Status Printer::visit(CheckCounter &s)
   }
   return Status();
 }
-#line 512 "CPrinter.nw"
+#line 509 "CPrinter.nw"
 Status Printer::visit(UnaryOp &op)
 {
   o << '(';
@@ -177,7 +174,7 @@ Status Printer::visit(UnaryOp &op)
   o << ')';
   return Status();
 }
-#line 526 "CPrinter.nw"
+#line 523 "CPrinter.nw"
 Status Printer::visit(BinaryOp &op)
 {
   o << '(';
@@ -195,7 +192,7 @@ Status Printer::visit(BinaryOp &op)
   o << ')';
   return Status();
 }
-#line 557 "CPrinter.nw"
+#line 554 "CPrinter.nw"
 Status Printer::visit(Literal &l)
 {
   assert(l.type);
@@ -211,7 +208,7 @@ Status Printer::visit(Literal &l)
   }
   return Status();
 }
-#line 585 "CPrinter.nw"
+#line 582 "CPrinter.nw"
 Status Printer::visit(FunctionCall &c)
 {
   assert(c.callee);
@@ -252,7 +249,7 @@ Status Printer::visit(FunctionCall &c)
   }
   return Status();
 }
-#line 634 "CPrinter.nw"
+#line 631 "CPrinter.nw"
 Status Printer::visit(ProcedureCall &c)
 {
   assert(c.procedure);
@@ -274,7 +271,7 @@ Status Printer::visit(ProcedureCall &c)
   o << ")";
   return Status();
 }
-#line 667 "CPrinter.nw"
+#line 664 "CPrinter.nw"
 void Printer::printInclude(string basename)
 {
 
@@ -314,7 +311,7 @@ void Printer::printInclude(string basename)
   if (needInclude)
     o << "#include \"" << basename << ".h\"\n";
 }
-#line 715 "CPrinter.nw"
+#line 712 "CPrinter.nw"
 void Printer::printDeclarations(string basename)
 {
 
@@ -632,9 +629,7 @@ void Printer::printDeclarations(string basename)
   for ( STmap::const_iterator i = stmap.begin() ; i != stmap.end() ; i++ ) {
     STexcl *e = dynamic_cast<STexcl*>((*i).first);
     if (e) {
-      char buf[15];
-      sprintf(buf, "_%d", stmap[e]);
-      stateVar[e] = string("_state.") + string(buf);
+      stateVar[e] = "_state." + std::to_string(stmap[e]);
       unsigned int bits = 1;
       while ( (1 << bits) < e->children.size() ) ++bits;
       o << "  unsigned int " << buf << " : " << bits << ";\n";
@@ -658,9 +653,7 @@ void Printer::printDeclarations(string basename)
   for ( STmap::const_iterator i = stmap.begin() ; i != stmap.end() ; i++ ) {
     STexcl *e = dynamic_cast<STexcl*>((*i).first);
     if (e) {
-      char buf[15];
-      sprintf(buf, "_state_%d", stmap[e]);
-      string var = uniqueID(buf);
+      const string var = uniqueID("_state_" + std::to_string(stmap[e]));
       stateVar[e] = var;
       o << "static unsigned char " << var;
       // Initialization of state of selection-tree root:
@@ -687,9 +680,7 @@ void Printer::printDeclarations(string basename)
 	if (*j) ++successors;
       if (successors > 1) {
 	// If there is more than one non-NULL successor, generate a variable
-	char buf[15];
-	sprintf(buf, "_term_%d", cfgmap[s]);
-	string var = uniqueID(buf);
+	const string var = uniqueID("_term_" + std::to_string(cfgmap[s]));
 	terminationVar[s] = var;
 	o << "static int " << var << ";\n";
       }
@@ -700,9 +691,7 @@ void Printer::printDeclarations(string basename)
 
   for ( vector<Counter*>::const_iterator i = m.counters.begin() ;
 	i != m.counters.end() ; i++ ) {
-    char buf[15];
-    sprintf(buf, "_counter_%d", static_cast<unsigned int>(i-m.counters.begin()) );
-    string var = uniqueID(buf);
+    const string var = uniqueID("_counter_" + std::to_string(static_cast<unsigned int>(i-m.counters.begin())));
     counterVar[*i] = var;
     o << "static int " << var << ";\n";
   }
@@ -730,7 +719,7 @@ void Printer::printDeclarations(string basename)
 #endif
 
 }
-#line 1142 "CPrinter.nw"
+#line 1131 "CPrinter.nw"
 void Printer::outputFunctions()
 {
   assert(m.signals);
@@ -751,7 +740,7 @@ void Printer::outputFunctions()
     }
   }
 }
-#line 1173 "CPrinter.nw"
+#line 1162 "CPrinter.nw"
 void Printer::resetInputs()
 {
   assert(m.signals);
@@ -769,7 +758,7 @@ void Printer::resetInputs()
     }
   }  
 }
-#line 1201 "CPrinter.nw"
+#line 1190 "CPrinter.nw"
 void Printer::ioDefinitions()
 {
   // Print input signal function definitions
@@ -806,7 +795,7 @@ void Printer::ioDefinitions()
     }
   }
 }
-#line 1258 "CPrinter.nw"
+#line 1247 "CPrinter.nw"
 void Printer::printStructuredCode(GRCNode *exit_node, unsigned int indent)
 {
   assert(exit_node);
@@ -820,7 +809,7 @@ void Printer::printStructuredCode(GRCNode *exit_node, unsigned int indent)
   dfsVisit(exit_node);
 
   
-#line 1320 "CPrinter.nw"
+#line 1309 "CPrinter.nw"
 ridom.clear();
 
 // Compute immediate dominators on the reverse graph
@@ -857,7 +846,7 @@ do {
   }
 } while (changed);
 
-#line 1272 "CPrinter.nw"
+#line 1261 "CPrinter.nw"
   GRCNode *entry_node = nodes.front();
 
   statementFor.clear();
@@ -871,7 +860,7 @@ do {
 
   delete root;
 }
-#line 1297 "CPrinter.nw"
+#line 1286 "CPrinter.nw"
 void Printer::dfsVisit(GRCNode *n)
 {
   if (!n || nodeNumber.find(n) != nodeNumber.end()) return;
@@ -886,14 +875,14 @@ void Printer::dfsVisit(GRCNode *n)
 
   // std::cerr << "Assigned node " << cfgmap[n] << " = " << nodeNumber[n] << '\n';
 }
-#line 1412 "CPrinter.nw"
+#line 1401 "CPrinter.nw"
 Printer *CStatement::printer = 0;
-#line 1416 "CPrinter.nw"
+#line 1405 "CPrinter.nw"
 void CStatement::indent(unsigned int n)
 {
   for (unsigned int i = 0 ; i < n ; i++) printer->o << "  ";
 }
-#line 1423 "CPrinter.nw"
+#line 1412 "CPrinter.nw"
 void CStatement::begin(unsigned int i)
 {
   if (!label.empty()) {
@@ -902,14 +891,14 @@ void CStatement::begin(unsigned int i)
   }
   indent(i);
 }
-#line 1435 "CPrinter.nw"
+#line 1424 "CPrinter.nw"
 void CStatement::print(unsigned int i)
 {
   begin(i);
   printer->printExpr(node);
   printer->o << ";\n";
 }
-#line 1444 "CPrinter.nw"
+#line 1433 "CPrinter.nw"
 void CIfElse::print(unsigned int i)
 {
   begin(i);
@@ -928,19 +917,19 @@ void CIfElse::print(unsigned int i)
     printer->o << "\n";
   }
 }
-#line 1465 "CPrinter.nw"
+#line 1454 "CPrinter.nw"
 void CGoto::print(unsigned int i)
 {
   begin(i);
   printer->o << "goto " << label << ";\n";
 }
-#line 1473 "CPrinter.nw"
+#line 1462 "CPrinter.nw"
 void CBreak::print(unsigned int i)
 {
   begin(i);
   printer->o << "break;\n";
 }
-#line 1481 "CPrinter.nw"
+#line 1470 "CPrinter.nw"
 void CSwitch::print(unsigned int i)
 {
   begin(i);
@@ -953,7 +942,7 @@ void CSwitch::print(unsigned int i)
   indent(i);
   printer->o << "}\n";
 }
-#line 1496 "CPrinter.nw"
+#line 1485 "CPrinter.nw"
 void CCase::print(unsigned int i)
 {
   indent(i > 0 ? i - 1 : 0);
@@ -961,7 +950,7 @@ void CCase::print(unsigned int i)
   assert(body);
   for ( CStatement *st = body ; st ; st = st->next ) st->print(i);
 }
-#line 1512 "CPrinter.nw"
+#line 1501 "CPrinter.nw"
 CStatement *Printer::synthesize(GRCNode *node, GRCNode *final, bool needBreak)
 {
   assert(node);
@@ -985,11 +974,8 @@ CStatement *Printer::synthesize(GRCNode *node, GRCNode *final, bool needBreak)
   if ( statementFor.find(node) != statementFor.end() ) {
     CStatement *target = statementFor[node];
     if (target->label.empty()) {
-      char buf[20];
-      // sprintf(buf, "L%d", nextLabel++);
       assert(cfgmap.find(node) != cfgmap.end());
-      sprintf(buf, "N%d", cfgmap[node]);
-      target->label = buf;
+      target->label = 'N' + std::to_string(cfgmap[node]);
     }
     return new CGoto(target->label);
   }
@@ -1068,5 +1054,5 @@ CStatement *Printer::synthesize(GRCNode *node, GRCNode *final, bool needBreak)
     result->label = labelFor[node];
   return result;
 }
-#line 1670 "CPrinter.nw"
+#line 1656 "CPrinter.nw"
 }

--- a/src/CPrinter.hpp
+++ b/src/CPrinter.hpp
@@ -1,4 +1,4 @@
-#line 1635 "CPrinter.nw"
+#line 1621 "CPrinter.nw"
 #ifndef _CPRINTER_HPP
 #  define _CPRINTER_HPP
 
@@ -19,7 +19,7 @@ namespace CPrinter {
   using std::map;
 
   
-#line 1623 "CPrinter.nw"
+#line 1609 "CPrinter.nw"
 template <class T> bool contains(set<T> &s, T o) {
    return s.find(o) != s.end();
 }
@@ -28,9 +28,9 @@ template <class T, class U> bool contains(map<T, U> &m, T o) {
   return m.find(o) != m.end();
 }
 
-#line 1656 "CPrinter.nw"
+#line 1642 "CPrinter.nw"
   
-#line 1360 "CPrinter.nw"
+#line 1349 "CPrinter.nw"
 class Printer;
 
 struct CStatement {
@@ -81,7 +81,7 @@ struct CCase : CStatement {
   void print(unsigned int = 0);
 };
 
-#line 1658 "CPrinter.nw"
+#line 1644 "CPrinter.nw"
   
 #line 22 "CPrinter.nw"
 class Printer : public Visitor {
@@ -131,18 +131,18 @@ public:
   
 #line 105 "CPrinter.nw"
 string uniqueID(string);
-#line 135 "CPrinter.nw"
+#line 132 "CPrinter.nw"
 void printExpr(ASTNode *n) { n->welcome(*this); }
-#line 144 "CPrinter.nw"
+#line 141 "CPrinter.nw"
 Status visit(Test &t) { printExpr(t.predicate); return Status(); }
 Status visit(Action &a) { printExpr(a.body); return Status(); }
-#line 153 "CPrinter.nw"
+#line 150 "CPrinter.nw"
 Status visit(EnterGRC&) { o << "1 /* EnterGRC */"; return Status(); }
 Status visit(ExitGRC&) { o << "/* ExitGRC */"; return Status(); }
 Status visit(STSuspend&) { o << "/* STSuspend */"; return Status(); }
-#line 164 "CPrinter.nw"
+#line 161 "CPrinter.nw"
 Status visit(Nop& n) { o << n.body; return Status(); }
-#line 172 "CPrinter.nw"
+#line 169 "CPrinter.nw"
 Status visit(Switch &s) {
   STexcl *e = dynamic_cast<STexcl*>(s.st);
   assert(e);
@@ -150,26 +150,26 @@ Status visit(Switch &s) {
   o << stateVar[e];
   return Status();
 }
-#line 189 "CPrinter.nw"
+#line 186 "CPrinter.nw"
 Status visit(Enter &);
-#line 246 "CPrinter.nw"
+#line 243 "CPrinter.nw"
 Status visit(Terminate &);
-#line 283 "CPrinter.nw"
+#line 280 "CPrinter.nw"
 Status visit(Sync &s) {
   if ( contains(terminationVar, &s) )
     o << '~' << terminationVar[&s];
   return Status();
 }
-#line 295 "CPrinter.nw"
+#line 292 "CPrinter.nw"
 Status visit(Fork &f) {
   if (f.sync && contains(terminationVar, f.sync))
     o << terminationVar[f.sync] << " = -1";
   return Status();
 }
-#line 312 "CPrinter.nw"
+#line 309 "CPrinter.nw"
 Status visit(Emit &);
 Status visit(Exit &);
-#line 364 "CPrinter.nw"
+#line 361 "CPrinter.nw"
 Status visit(DefineSignal &d)
 {
   assert(contains(presenceVar, d.signal));
@@ -189,7 +189,7 @@ Status visit(DefineSignal &d)
   o << ';';
   return Status();
 }
-#line 388 "CPrinter.nw"
+#line 385 "CPrinter.nw"
 Status visit(Assign &a) {
   assert(a.variable->type);
   assert(contains(variableVar, a.variable));
@@ -212,17 +212,17 @@ Status visit(Assign &a) {
   }
   return Status();
 }
-#line 417 "CPrinter.nw"
+#line 414 "CPrinter.nw"
 Status visit(StartCounter &);
-#line 437 "CPrinter.nw"
+#line 434 "CPrinter.nw"
 Status visit(CheckCounter &);
-#line 464 "CPrinter.nw"
+#line 461 "CPrinter.nw"
 Status visit(LoadSignalExpression &e) {
   assert(contains(presenceVar, e.signal));
   o << presenceVar[e.signal];
   return Status();
 }
-#line 483 "CPrinter.nw"
+#line 480 "CPrinter.nw"
 Status visit(LoadSignalValueExpression &e) {
   assert(e.signal);
   assert(contains(valueVar, e.signal));
@@ -237,40 +237,40 @@ Status visit(LoadSignalValueExpression &e) {
   }
   return Status();
 }
-#line 502 "CPrinter.nw"
+#line 499 "CPrinter.nw"
 Status visit(LoadVariableExpression &e) {
   assert(contains(variableVar, e.variable));
   o << variableVar[e.variable];
   return Status();
 }
-#line 546 "CPrinter.nw"
+#line 543 "CPrinter.nw"
 Status visit(UnaryOp &);
 Status visit(BinaryOp &);
-#line 553 "CPrinter.nw"
+#line 550 "CPrinter.nw"
 Status visit(Literal &);
-#line 581 "CPrinter.nw"
+#line 578 "CPrinter.nw"
 Status visit(FunctionCall &);
-#line 630 "CPrinter.nw"
+#line 627 "CPrinter.nw"
 Status visit(ProcedureCall &);
-#line 663 "CPrinter.nw"
+#line 660 "CPrinter.nw"
 virtual void printInclude(string);
-#line 711 "CPrinter.nw"
+#line 708 "CPrinter.nw"
 virtual void printDeclarations(string);
-#line 1138 "CPrinter.nw"
+#line 1127 "CPrinter.nw"
 virtual void outputFunctions();
-#line 1169 "CPrinter.nw"
+#line 1158 "CPrinter.nw"
 virtual void resetInputs();
-#line 1197 "CPrinter.nw"
+#line 1186 "CPrinter.nw"
 virtual void ioDefinitions();
-#line 1254 "CPrinter.nw"
+#line 1243 "CPrinter.nw"
 void printStructuredCode(GRCNode *, unsigned int = 0);
-#line 1293 "CPrinter.nw"
+#line 1282 "CPrinter.nw"
 void dfsVisit(GRCNode*);
-#line 1508 "CPrinter.nw"
+#line 1497 "CPrinter.nw"
 CStatement *synthesize(GRCNode*, GRCNode*, bool);
 #line 67 "CPrinter.nw"
 };
-#line 1659 "CPrinter.nw"
+#line 1645 "CPrinter.nw"
 }
 
 #endif

--- a/src/CPrinter.nw
+++ b/src/CPrinter.nw
@@ -86,13 +86,13 @@ Printer::Printer(std::ostream &o, Module &m, bool three_val)
   // Note: float and double aren't in this list because they are equivalent
   // to Esterel's types of the same name
 
-  char *keywords[] = {
+  const char *keywords[] = {
     "int", "break", "char", "continue", "if", "else",
     "struct", "for", "auto", "do", "extern", "while", "register", "switch",
     "static", "case", "goto", "default", "return", "entry", "sizeof", NULL
   };
 
-  for (char **k = keywords ; *k != NULL ; k++) identifiers.insert(*k);
+  for (const char **k = keywords ; *k != NULL ; k++) identifiers.insert(*k);
 }
 @
 
@@ -1098,7 +1098,7 @@ void Printer::printDeclarations(string basename)
   for ( vector<Counter*>::const_iterator i = m.counters.begin() ;
 	i != m.counters.end() ; i++ ) {
     char buf[15];
-    sprintf(buf, "_counter_%d", i-m.counters.begin() );
+    sprintf(buf, "_counter_%d", static_cast<unsigned int>(i-m.counters.begin()) );
     string var = uniqueID(buf);
     counterVar[*i] = var;
     o << "static int " << var << ";\n";

--- a/src/CPrinter.nw
+++ b/src/CPrinter.nw
@@ -110,12 +110,9 @@ string Printer::uniqueID(string name)
 {
   string newname = name;
 
-  char buf[10];
   int version = 1;
-
   while (contains(identifiers, newname)) {
-    sprintf(buf, "%d", version++);
-    newname = name + '_' + buf;
+    newname = name + '_' + std::to_string(version++);
   }
   
   identifiers.insert(newname);
@@ -1029,9 +1026,7 @@ void Printer::printDeclarations(string basename)
   for ( STmap::const_iterator i = stmap.begin() ; i != stmap.end() ; i++ ) {
     STexcl *e = dynamic_cast<STexcl*>((*i).first);
     if (e) {
-      char buf[15];
-      sprintf(buf, "_%d", stmap[e]);
-      stateVar[e] = string("_state.") + string(buf);
+      stateVar[e] = "_state." + std::to_string(stmap[e]);
       unsigned int bits = 1;
       while ( (1 << bits) < e->children.size() ) ++bits;
       o << "  unsigned int " << buf << " : " << bits << ";\n";
@@ -1055,9 +1050,7 @@ void Printer::printDeclarations(string basename)
   for ( STmap::const_iterator i = stmap.begin() ; i != stmap.end() ; i++ ) {
     STexcl *e = dynamic_cast<STexcl*>((*i).first);
     if (e) {
-      char buf[15];
-      sprintf(buf, "_state_%d", stmap[e]);
-      string var = uniqueID(buf);
+      const string var = uniqueID("_state_" + std::to_string(stmap[e]));
       stateVar[e] = var;
       o << "static unsigned char " << var;
       // Initialization of state of selection-tree root:
@@ -1084,9 +1077,7 @@ void Printer::printDeclarations(string basename)
 	if (*j) ++successors;
       if (successors > 1) {
 	// If there is more than one non-NULL successor, generate a variable
-	char buf[15];
-	sprintf(buf, "_term_%d", cfgmap[s]);
-	string var = uniqueID(buf);
+	const string var = uniqueID("_term_" + std::to_string(cfgmap[s]));
 	terminationVar[s] = var;
 	o << "static int " << var << ";\n";
       }
@@ -1097,9 +1088,7 @@ void Printer::printDeclarations(string basename)
 
   for ( vector<Counter*>::const_iterator i = m.counters.begin() ;
 	i != m.counters.end() ; i++ ) {
-    char buf[15];
-    sprintf(buf, "_counter_%d", static_cast<unsigned int>(i-m.counters.begin()) );
-    string var = uniqueID(buf);
+    const string var = uniqueID("_counter_" + std::to_string(static_cast<unsigned int>(i-m.counters.begin())));
     counterVar[*i] = var;
     o << "static int " << var << ";\n";
   }
@@ -1532,11 +1521,8 @@ CStatement *Printer::synthesize(GRCNode *node, GRCNode *final, bool needBreak)
   if ( statementFor.find(node) != statementFor.end() ) {
     CStatement *target = statementFor[node];
     if (target->label.empty()) {
-      char buf[20];
-      // sprintf(buf, "L%d", nextLabel++);
       assert(cfgmap.find(node) != cfgmap.end());
-      sprintf(buf, "N%d", cfgmap[node]);
-      target->label = buf;
+      target->label = 'N' + std::to_string(cfgmap[node]);
     }
     return new CGoto(target->label);
   }

--- a/src/Dismantle.cpp
+++ b/src/Dismantle.cpp
@@ -1,4 +1,4 @@
-#line 796 "Dismantle.nw"
+#line 794 "Dismantle.nw"
 #include <stdio.h>
 #include "Dismantle.hpp"
 

--- a/src/Dismantle.hpp
+++ b/src/Dismantle.hpp
@@ -1,4 +1,4 @@
-#line 776 "Dismantle.nw"
+#line 774 "Dismantle.nw"
 #ifndef _DISMANTLE_HPP
 #  define _DISMANTLE_HPP
 
@@ -216,7 +216,7 @@ Status visit(Delay &e) {
 }
 #line 57 "Dismantle.nw"
 };
-#line 790 "Dismantle.nw"
+#line 788 "Dismantle.nw"
   
 #line 328 "Dismantle.nw"
 class Dismantler1 : public Rewriter {
@@ -315,14 +315,12 @@ Trap *newTrap(SignalSymbol *&ts) {
   result->symbols = new SymbolTable();
   // Note: The parent of this symbol table is incorrectly NULL
 
-  char buf[10];
-  sprintf(buf, "%d", nextIndex++);
-  string name = "weak_trap_" + string(buf);
+  string name = "weak_trap_" + std::to_string(nextIndex++);
   ts = new SignalSymbol(name, NULL, SignalSymbol::Trap, NULL, NULL, NULL);
   result->symbols->enter(ts);
   return result;
 }
-#line 546 "Dismantle.nw"
+#line 544 "Dismantle.nw"
 Status visit(Abort &a) { 
   if (a.is_weak) {
 
@@ -369,7 +367,7 @@ Status visit(Abort &a) {
     return Rewriter::visit(a);
   }
 }
-#line 613 "Dismantle.nw"
+#line 611 "Dismantle.nw"
 Status visit(Var &v) {
 
   bool hasInitializer = false;
@@ -406,34 +404,34 @@ Status visit(Var &v) {
   rewrite(v.body);
   return &v;
 }
-#line 668 "Dismantle.nw"
+#line 666 "Dismantle.nw"
 Status visit(DoWatching &s) {
   return transform(new Abort(s.body, s.predicate, s.timeout));
 }
-#line 689 "Dismantle.nw"
+#line 687 "Dismantle.nw"
 Status visit(DoUpto &s) {
   return transform(new Abort(&(sl() << s.body << new Halt()), s.predicate, 0));
 }
-#line 715 "Dismantle.nw"
+#line 713 "Dismantle.nw"
 Status visit(LoopEach &s) {
   return transform(new Loop(new Abort(&(sl() << s.body << new Halt()),
 				      s.predicate, 0)));
 }
-#line 736 "Dismantle.nw"
+#line 734 "Dismantle.nw"
 Status visit(Halt &s) {
   return transform(new Loop(new Pause()));
 }
-#line 757 "Dismantle.nw"
+#line 755 "Dismantle.nw"
 Status visit(Sustain &s) {
   return transform(new Loop(&(sl() <<
 			      new Emit(s.signal, s.value) << new Pause())));
 }
-#line 768 "Dismantle.nw"
+#line 766 "Dismantle.nw"
 Status visit(Nothing &) {
   return transform(new StatementList());
 }
 #line 331 "Dismantle.nw"
 };
-#line 791 "Dismantle.nw"
+#line 789 "Dismantle.nw"
 }
 #endif

--- a/src/Dismantle.nw
+++ b/src/Dismantle.nw
@@ -533,9 +533,7 @@ Trap *newTrap(SignalSymbol *&ts) {
   result->symbols = new SymbolTable();
   // Note: The parent of this symbol table is incorrectly NULL
 
-  char buf[10];
-  sprintf(buf, "%d", nextIndex++);
-  string name = "weak_trap_" + string(buf);
+  string name = "weak_trap_" + std::to_string(nextIndex++);
   ts = new SignalSymbol(name, NULL, SignalSymbol::Trap, NULL, NULL, NULL);
   result->symbols->enter(ts);
   return result;

--- a/src/EsterelLexer.cpp
+++ b/src/EsterelLexer.cpp
@@ -1,4 +1,4 @@
-/* $ANTLR 2.7.2: "esterel.g" -> "EsterelLexer.cpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "esterel.g" -> "EsterelLexer.cpp"$ */
 #include "EsterelLexer.hpp"
 #include <antlr/CharBuffer.hpp>
 #include <antlr/TokenStreamException.hpp>
@@ -30,58 +30,58 @@ EsterelLexer::EsterelLexer(const ANTLR_USE_NAMESPACE(antlr)LexerSharedInputState
 
 void EsterelLexer::initLiterals()
 {
+	literals["copymodule"] = 114;
+	literals["pause"] = 83;
 	literals["exec"] = 110;
-	literals["times"] = 97;
 	literals["sustain"] = 86;
 	literals["case"] = 91;
-	literals["procedure"] = 47;
 	literals["loop"] = 102;
 	literals["trap"] = 106;
 	literals["immediate"] = 78;
-	literals["pause"] = 83;
-	literals["copymodule"] = 114;
+	literals["procedure"] = 47;
+	literals["times"] = 97;
 	literals["call"] = 87;
 	literals["exit"] = 108;
 	literals["present"] = 88;
-	literals["abort"] = 98;
+	literals["false"] = 77;
 	literals["true"] = 76;
 	literals["sensor"] = 60;
-	literals["await"] = 101;
 	literals["and"] = 59;
-	literals["input"] = 49;
+	literals["elsif"] = 94;
 	literals["nothing"] = 82;
 	literals["suspend"] = 105;
-	literals["positive"] = 95;
 	literals["pre"] = 74;
 	literals["end"] = 36;
 	literals["upto"] = 117;
-	literals["every"] = 104;
+	literals["handle"] = 109;
 	literals["when"] = 99;
 	literals["signal"] = 111;
-	literals["output"] = 50;
 	literals["timeout"] = 116;
+	literals["combine"] = 54;
 	literals["mod"] = 72;
 	literals["do"] = 92;
 	literals["type"] = 38;
 	literals["in"] = 107;
-	literals["combine"] = 54;
 	literals["watching"] = 115;
 	literals["function"] = 44;
 	literals["inputoutput"] = 51;
+	literals["output"] = 50;
 	literals["each"] = 103;
-	literals["handle"] = 109;
+	literals["every"] = 104;
 	literals["repeat"] = 96;
 	literals["or"] = 58;
 	literals["constant"] = 41;
-	literals["elsif"] = 94;
-	literals["relation"] = 61;
+	literals["positive"] = 95;
 	literals["return"] = 52;
+	literals["relation"] = 61;
+	literals["input"] = 49;
 	literals["emit"] = 85;
 	literals["if"] = 93;
 	literals["task"] = 48;
+	literals["await"] = 101;
 	literals["run"] = 113;
 	literals["halt"] = 84;
-	literals["false"] = 77;
+	literals["abort"] = 98;
 	literals["module"] = 34;
 	literals["else"] = 90;
 	literals["var"] = 112;
@@ -100,227 +100,227 @@ ANTLR_USE_NAMESPACE(antlr)RefToken EsterelLexer::nextToken()
 		resetText();
 		try {   // for lexical and char stream error handling
 			switch ( LA(1)) {
-			case static_cast<unsigned char>('#'):
+			case 0x23 /* '#' */ :
 			{
 				mPOUND(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('+'):
+			case 0x2b /* '+' */ :
 			{
 				mPLUS(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('-'):
+			case 0x2d /* '-' */ :
 			{
 				mDASH(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('/'):
+			case 0x2f /* '/' */ :
 			{
 				mSLASH(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('*'):
+			case 0x2a /* '*' */ :
 			{
 				mSTAR(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('|'):
+			case 0x7c /* '|' */ :
 			{
 				mPARALLEL(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>(','):
+			case 0x2c /* ',' */ :
 			{
 				mCOMMA(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>(';'):
+			case 0x3b /* ';' */ :
 			{
 				mSEMICOLON(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('('):
+			case 0x28 /* '(' */ :
 			{
 				mLPAREN(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>(')'):
+			case 0x29 /* ')' */ :
 			{
 				mRPAREN(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('['):
+			case 0x5b /* '[' */ :
 			{
 				mLBRACKET(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>(']'):
+			case 0x5d /* ']' */ :
 			{
 				mRBRACKET(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('A'):
-			case static_cast<unsigned char>('B'):
-			case static_cast<unsigned char>('C'):
-			case static_cast<unsigned char>('D'):
-			case static_cast<unsigned char>('E'):
-			case static_cast<unsigned char>('F'):
-			case static_cast<unsigned char>('G'):
-			case static_cast<unsigned char>('H'):
-			case static_cast<unsigned char>('I'):
-			case static_cast<unsigned char>('J'):
-			case static_cast<unsigned char>('K'):
-			case static_cast<unsigned char>('L'):
-			case static_cast<unsigned char>('M'):
-			case static_cast<unsigned char>('N'):
-			case static_cast<unsigned char>('O'):
-			case static_cast<unsigned char>('P'):
-			case static_cast<unsigned char>('Q'):
-			case static_cast<unsigned char>('R'):
-			case static_cast<unsigned char>('S'):
-			case static_cast<unsigned char>('T'):
-			case static_cast<unsigned char>('U'):
-			case static_cast<unsigned char>('V'):
-			case static_cast<unsigned char>('W'):
-			case static_cast<unsigned char>('X'):
-			case static_cast<unsigned char>('Y'):
-			case static_cast<unsigned char>('Z'):
-			case static_cast<unsigned char>('a'):
-			case static_cast<unsigned char>('b'):
-			case static_cast<unsigned char>('c'):
-			case static_cast<unsigned char>('d'):
-			case static_cast<unsigned char>('e'):
-			case static_cast<unsigned char>('f'):
-			case static_cast<unsigned char>('g'):
-			case static_cast<unsigned char>('h'):
-			case static_cast<unsigned char>('i'):
-			case static_cast<unsigned char>('j'):
-			case static_cast<unsigned char>('k'):
-			case static_cast<unsigned char>('l'):
-			case static_cast<unsigned char>('m'):
-			case static_cast<unsigned char>('n'):
-			case static_cast<unsigned char>('o'):
-			case static_cast<unsigned char>('p'):
-			case static_cast<unsigned char>('q'):
-			case static_cast<unsigned char>('r'):
-			case static_cast<unsigned char>('s'):
-			case static_cast<unsigned char>('t'):
-			case static_cast<unsigned char>('u'):
-			case static_cast<unsigned char>('v'):
-			case static_cast<unsigned char>('w'):
-			case static_cast<unsigned char>('x'):
-			case static_cast<unsigned char>('y'):
-			case static_cast<unsigned char>('z'):
+			case 0x41 /* 'A' */ :
+			case 0x42 /* 'B' */ :
+			case 0x43 /* 'C' */ :
+			case 0x44 /* 'D' */ :
+			case 0x45 /* 'E' */ :
+			case 0x46 /* 'F' */ :
+			case 0x47 /* 'G' */ :
+			case 0x48 /* 'H' */ :
+			case 0x49 /* 'I' */ :
+			case 0x4a /* 'J' */ :
+			case 0x4b /* 'K' */ :
+			case 0x4c /* 'L' */ :
+			case 0x4d /* 'M' */ :
+			case 0x4e /* 'N' */ :
+			case 0x4f /* 'O' */ :
+			case 0x50 /* 'P' */ :
+			case 0x51 /* 'Q' */ :
+			case 0x52 /* 'R' */ :
+			case 0x53 /* 'S' */ :
+			case 0x54 /* 'T' */ :
+			case 0x55 /* 'U' */ :
+			case 0x56 /* 'V' */ :
+			case 0x57 /* 'W' */ :
+			case 0x58 /* 'X' */ :
+			case 0x59 /* 'Y' */ :
+			case 0x5a /* 'Z' */ :
+			case 0x61 /* 'a' */ :
+			case 0x62 /* 'b' */ :
+			case 0x63 /* 'c' */ :
+			case 0x64 /* 'd' */ :
+			case 0x65 /* 'e' */ :
+			case 0x66 /* 'f' */ :
+			case 0x67 /* 'g' */ :
+			case 0x68 /* 'h' */ :
+			case 0x69 /* 'i' */ :
+			case 0x6a /* 'j' */ :
+			case 0x6b /* 'k' */ :
+			case 0x6c /* 'l' */ :
+			case 0x6d /* 'm' */ :
+			case 0x6e /* 'n' */ :
+			case 0x6f /* 'o' */ :
+			case 0x70 /* 'p' */ :
+			case 0x71 /* 'q' */ :
+			case 0x72 /* 'r' */ :
+			case 0x73 /* 's' */ :
+			case 0x74 /* 't' */ :
+			case 0x75 /* 'u' */ :
+			case 0x76 /* 'v' */ :
+			case 0x77 /* 'w' */ :
+			case 0x78 /* 'x' */ :
+			case 0x79 /* 'y' */ :
+			case 0x7a /* 'z' */ :
 			{
 				mID(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('0'):
-			case static_cast<unsigned char>('1'):
-			case static_cast<unsigned char>('2'):
-			case static_cast<unsigned char>('3'):
-			case static_cast<unsigned char>('4'):
-			case static_cast<unsigned char>('5'):
-			case static_cast<unsigned char>('6'):
-			case static_cast<unsigned char>('7'):
-			case static_cast<unsigned char>('8'):
-			case static_cast<unsigned char>('9'):
+			case 0x30 /* '0' */ :
+			case 0x31 /* '1' */ :
+			case 0x32 /* '2' */ :
+			case 0x33 /* '3' */ :
+			case 0x34 /* '4' */ :
+			case 0x35 /* '5' */ :
+			case 0x36 /* '6' */ :
+			case 0x37 /* '7' */ :
+			case 0x38 /* '8' */ :
+			case 0x39 /* '9' */ :
 			{
 				mNumber(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('"'):
+			case 0x22 /* '\"' */ :
 			{
 				mStringConstant(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('\t'):
-			case static_cast<unsigned char>('\14'):
-			case static_cast<unsigned char>(' '):
+			case 0x9 /* '\t' */ :
+			case 0xc /* '\14' */ :
+			case 0x20 /* ' ' */ :
 			{
 				mWhitespace(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('\n'):
-			case static_cast<unsigned char>('\r'):
+			case 0xa /* '\n' */ :
+			case 0xd /* '\r' */ :
 			{
 				mNewline(true);
 				theRetToken=_returnToken;
 				break;
 			}
-			case static_cast<unsigned char>('%'):
+			case 0x25 /* '%' */ :
 			{
 				mComment(true);
 				theRetToken=_returnToken;
 				break;
 			}
 			default:
-				if ((LA(1) == static_cast<unsigned char>(':')) && (LA(2) == static_cast<unsigned char>('='))) {
+				if ((LA(1) == 0x3a /* ':' */ ) && (LA(2) == 0x3d /* '=' */ )) {
 					mCOLEQUALS(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('?')) && (LA(2) == static_cast<unsigned char>('?'))) {
+				else if ((LA(1) == 0x3f /* '?' */ ) && (LA(2) == 0x3f /* '?' */ )) {
 					mDQUESTION(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('<')) && (LA(2) == static_cast<unsigned char>('='))) {
+				else if ((LA(1) == 0x3c /* '<' */ ) && (LA(2) == 0x3d /* '=' */ )) {
 					mLEQUAL(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('>')) && (LA(2) == static_cast<unsigned char>('='))) {
+				else if ((LA(1) == 0x3e /* '>' */ ) && (LA(2) == 0x3d /* '=' */ )) {
 					mGEQUAL(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('<')) && (LA(2) == static_cast<unsigned char>('>'))) {
+				else if ((LA(1) == 0x3c /* '<' */ ) && (LA(2) == 0x3e /* '>' */ )) {
 					mNEQUAL(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('=')) && (LA(2) == static_cast<unsigned char>('>'))) {
+				else if ((LA(1) == 0x3d /* '=' */ ) && (LA(2) == 0x3e /* '>' */ )) {
 					mIMPLIES(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('.')) && ((LA(2) >= static_cast<unsigned char>('0') && LA(2) <= static_cast<unsigned char>('9')))) {
+				else if ((LA(1) == 0x2e /* '.' */ ) && ((LA(2) >= 0x30 /* '0' */  && LA(2) <= 0x39 /* '9' */ ))) {
 					mFractionalNumber(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('.')) && (true)) {
+				else if ((LA(1) == 0x2e /* '.' */ ) && (true)) {
 					mPERIOD(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('<')) && (true)) {
+				else if ((LA(1) == 0x3c /* '<' */ ) && (true)) {
 					mLESSTHAN(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('>')) && (true)) {
+				else if ((LA(1) == 0x3e /* '>' */ ) && (true)) {
 					mGREATERTHAN(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('=')) && (true)) {
+				else if ((LA(1) == 0x3d /* '=' */ ) && (true)) {
 					mEQUALS(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>(':')) && (true)) {
+				else if ((LA(1) == 0x3a /* ':' */ ) && (true)) {
 					mCOLON(true);
 					theRetToken=_returnToken;
 				}
-				else if ((LA(1) == static_cast<unsigned char>('?')) && (true)) {
+				else if ((LA(1) == 0x3f /* '?' */ ) && (true)) {
 					mQUESTION(true);
 					theRetToken=_returnToken;
 				}
@@ -354,11 +354,11 @@ tryAgain:;
 }
 
 void EsterelLexer::mPERIOD(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = PERIOD;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('.'));
+	match('.' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -368,11 +368,11 @@ void EsterelLexer::mPERIOD(bool _createToken) {
 }
 
 void EsterelLexer::mPOUND(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = POUND;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('#'));
+	match('#' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -382,11 +382,11 @@ void EsterelLexer::mPOUND(bool _createToken) {
 }
 
 void EsterelLexer::mPLUS(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = PLUS;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('+'));
+	match('+' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -396,11 +396,11 @@ void EsterelLexer::mPLUS(bool _createToken) {
 }
 
 void EsterelLexer::mDASH(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = DASH;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('-'));
+	match('-' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -410,11 +410,11 @@ void EsterelLexer::mDASH(bool _createToken) {
 }
 
 void EsterelLexer::mSLASH(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = SLASH;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('/'));
+	match('/' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -424,11 +424,11 @@ void EsterelLexer::mSLASH(bool _createToken) {
 }
 
 void EsterelLexer::mSTAR(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = STAR;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('*'));
+	match('*' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -438,9 +438,9 @@ void EsterelLexer::mSTAR(bool _createToken) {
 }
 
 void EsterelLexer::mPARALLEL(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = PARALLEL;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match("||");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -452,11 +452,11 @@ void EsterelLexer::mPARALLEL(bool _createToken) {
 }
 
 void EsterelLexer::mLESSTHAN(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = LESSTHAN;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('<'));
+	match('<' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -466,11 +466,11 @@ void EsterelLexer::mLESSTHAN(bool _createToken) {
 }
 
 void EsterelLexer::mGREATERTHAN(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = GREATERTHAN;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('>'));
+	match('>' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -480,11 +480,11 @@ void EsterelLexer::mGREATERTHAN(bool _createToken) {
 }
 
 void EsterelLexer::mCOMMA(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = COMMA;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>(','));
+	match(',' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -494,11 +494,11 @@ void EsterelLexer::mCOMMA(bool _createToken) {
 }
 
 void EsterelLexer::mEQUALS(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = EQUALS;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('='));
+	match('=' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -508,11 +508,11 @@ void EsterelLexer::mEQUALS(bool _createToken) {
 }
 
 void EsterelLexer::mSEMICOLON(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = SEMICOLON;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>(';'));
+	match(';' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -522,11 +522,11 @@ void EsterelLexer::mSEMICOLON(bool _createToken) {
 }
 
 void EsterelLexer::mCOLON(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = COLON;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>(':'));
+	match(':' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -536,9 +536,9 @@ void EsterelLexer::mCOLON(bool _createToken) {
 }
 
 void EsterelLexer::mCOLEQUALS(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = COLEQUALS;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match(":=");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -550,11 +550,11 @@ void EsterelLexer::mCOLEQUALS(bool _createToken) {
 }
 
 void EsterelLexer::mLPAREN(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = LPAREN;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('('));
+	match('(' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -564,11 +564,11 @@ void EsterelLexer::mLPAREN(bool _createToken) {
 }
 
 void EsterelLexer::mRPAREN(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = RPAREN;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>(')'));
+	match(')' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -578,11 +578,11 @@ void EsterelLexer::mRPAREN(bool _createToken) {
 }
 
 void EsterelLexer::mLBRACKET(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = LBRACKET;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('['));
+	match('[' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -592,11 +592,11 @@ void EsterelLexer::mLBRACKET(bool _createToken) {
 }
 
 void EsterelLexer::mRBRACKET(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = RBRACKET;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>(']'));
+	match(']' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -606,11 +606,11 @@ void EsterelLexer::mRBRACKET(bool _createToken) {
 }
 
 void EsterelLexer::mQUESTION(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = QUESTION;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('?'));
+	match('?' /* charlit */ );
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
 	   _token->setText(text.substr(_begin, text.length()-_begin));
@@ -620,9 +620,9 @@ void EsterelLexer::mQUESTION(bool _createToken) {
 }
 
 void EsterelLexer::mDQUESTION(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = DQUESTION;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match("??");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -634,9 +634,9 @@ void EsterelLexer::mDQUESTION(bool _createToken) {
 }
 
 void EsterelLexer::mLEQUAL(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = LEQUAL;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match("<=");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -648,9 +648,9 @@ void EsterelLexer::mLEQUAL(bool _createToken) {
 }
 
 void EsterelLexer::mGEQUAL(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = GEQUAL;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match(">=");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -662,9 +662,9 @@ void EsterelLexer::mGEQUAL(bool _createToken) {
 }
 
 void EsterelLexer::mNEQUAL(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = NEQUAL;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match("<>");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -676,9 +676,9 @@ void EsterelLexer::mNEQUAL(bool _createToken) {
 }
 
 void EsterelLexer::mIMPLIES(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = IMPLIES;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	match("=>");
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
@@ -690,70 +690,70 @@ void EsterelLexer::mIMPLIES(bool _createToken) {
 }
 
 void EsterelLexer::mID(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = ID;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	{
 	switch ( LA(1)) {
-	case static_cast<unsigned char>('a'):
-	case static_cast<unsigned char>('b'):
-	case static_cast<unsigned char>('c'):
-	case static_cast<unsigned char>('d'):
-	case static_cast<unsigned char>('e'):
-	case static_cast<unsigned char>('f'):
-	case static_cast<unsigned char>('g'):
-	case static_cast<unsigned char>('h'):
-	case static_cast<unsigned char>('i'):
-	case static_cast<unsigned char>('j'):
-	case static_cast<unsigned char>('k'):
-	case static_cast<unsigned char>('l'):
-	case static_cast<unsigned char>('m'):
-	case static_cast<unsigned char>('n'):
-	case static_cast<unsigned char>('o'):
-	case static_cast<unsigned char>('p'):
-	case static_cast<unsigned char>('q'):
-	case static_cast<unsigned char>('r'):
-	case static_cast<unsigned char>('s'):
-	case static_cast<unsigned char>('t'):
-	case static_cast<unsigned char>('u'):
-	case static_cast<unsigned char>('v'):
-	case static_cast<unsigned char>('w'):
-	case static_cast<unsigned char>('x'):
-	case static_cast<unsigned char>('y'):
-	case static_cast<unsigned char>('z'):
+	case 0x61 /* 'a' */ :
+	case 0x62 /* 'b' */ :
+	case 0x63 /* 'c' */ :
+	case 0x64 /* 'd' */ :
+	case 0x65 /* 'e' */ :
+	case 0x66 /* 'f' */ :
+	case 0x67 /* 'g' */ :
+	case 0x68 /* 'h' */ :
+	case 0x69 /* 'i' */ :
+	case 0x6a /* 'j' */ :
+	case 0x6b /* 'k' */ :
+	case 0x6c /* 'l' */ :
+	case 0x6d /* 'm' */ :
+	case 0x6e /* 'n' */ :
+	case 0x6f /* 'o' */ :
+	case 0x70 /* 'p' */ :
+	case 0x71 /* 'q' */ :
+	case 0x72 /* 'r' */ :
+	case 0x73 /* 's' */ :
+	case 0x74 /* 't' */ :
+	case 0x75 /* 'u' */ :
+	case 0x76 /* 'v' */ :
+	case 0x77 /* 'w' */ :
+	case 0x78 /* 'x' */ :
+	case 0x79 /* 'y' */ :
+	case 0x7a /* 'z' */ :
 	{
-		matchRange(static_cast<unsigned char>('a'),static_cast<unsigned char>('z'));
+		matchRange('a','z');
 		break;
 	}
-	case static_cast<unsigned char>('A'):
-	case static_cast<unsigned char>('B'):
-	case static_cast<unsigned char>('C'):
-	case static_cast<unsigned char>('D'):
-	case static_cast<unsigned char>('E'):
-	case static_cast<unsigned char>('F'):
-	case static_cast<unsigned char>('G'):
-	case static_cast<unsigned char>('H'):
-	case static_cast<unsigned char>('I'):
-	case static_cast<unsigned char>('J'):
-	case static_cast<unsigned char>('K'):
-	case static_cast<unsigned char>('L'):
-	case static_cast<unsigned char>('M'):
-	case static_cast<unsigned char>('N'):
-	case static_cast<unsigned char>('O'):
-	case static_cast<unsigned char>('P'):
-	case static_cast<unsigned char>('Q'):
-	case static_cast<unsigned char>('R'):
-	case static_cast<unsigned char>('S'):
-	case static_cast<unsigned char>('T'):
-	case static_cast<unsigned char>('U'):
-	case static_cast<unsigned char>('V'):
-	case static_cast<unsigned char>('W'):
-	case static_cast<unsigned char>('X'):
-	case static_cast<unsigned char>('Y'):
-	case static_cast<unsigned char>('Z'):
+	case 0x41 /* 'A' */ :
+	case 0x42 /* 'B' */ :
+	case 0x43 /* 'C' */ :
+	case 0x44 /* 'D' */ :
+	case 0x45 /* 'E' */ :
+	case 0x46 /* 'F' */ :
+	case 0x47 /* 'G' */ :
+	case 0x48 /* 'H' */ :
+	case 0x49 /* 'I' */ :
+	case 0x4a /* 'J' */ :
+	case 0x4b /* 'K' */ :
+	case 0x4c /* 'L' */ :
+	case 0x4d /* 'M' */ :
+	case 0x4e /* 'N' */ :
+	case 0x4f /* 'O' */ :
+	case 0x50 /* 'P' */ :
+	case 0x51 /* 'Q' */ :
+	case 0x52 /* 'R' */ :
+	case 0x53 /* 'S' */ :
+	case 0x54 /* 'T' */ :
+	case 0x55 /* 'U' */ :
+	case 0x56 /* 'V' */ :
+	case 0x57 /* 'W' */ :
+	case 0x58 /* 'X' */ :
+	case 0x59 /* 'Y' */ :
+	case 0x5a /* 'Z' */ :
 	{
-		matchRange(static_cast<unsigned char>('A'),static_cast<unsigned char>('Z'));
+		matchRange('A','Z');
 		break;
 	}
 	default:
@@ -765,83 +765,83 @@ void EsterelLexer::mID(bool _createToken) {
 	{ // ( ... )*
 	for (;;) {
 		switch ( LA(1)) {
-		case static_cast<unsigned char>('a'):
-		case static_cast<unsigned char>('b'):
-		case static_cast<unsigned char>('c'):
-		case static_cast<unsigned char>('d'):
-		case static_cast<unsigned char>('e'):
-		case static_cast<unsigned char>('f'):
-		case static_cast<unsigned char>('g'):
-		case static_cast<unsigned char>('h'):
-		case static_cast<unsigned char>('i'):
-		case static_cast<unsigned char>('j'):
-		case static_cast<unsigned char>('k'):
-		case static_cast<unsigned char>('l'):
-		case static_cast<unsigned char>('m'):
-		case static_cast<unsigned char>('n'):
-		case static_cast<unsigned char>('o'):
-		case static_cast<unsigned char>('p'):
-		case static_cast<unsigned char>('q'):
-		case static_cast<unsigned char>('r'):
-		case static_cast<unsigned char>('s'):
-		case static_cast<unsigned char>('t'):
-		case static_cast<unsigned char>('u'):
-		case static_cast<unsigned char>('v'):
-		case static_cast<unsigned char>('w'):
-		case static_cast<unsigned char>('x'):
-		case static_cast<unsigned char>('y'):
-		case static_cast<unsigned char>('z'):
+		case 0x61 /* 'a' */ :
+		case 0x62 /* 'b' */ :
+		case 0x63 /* 'c' */ :
+		case 0x64 /* 'd' */ :
+		case 0x65 /* 'e' */ :
+		case 0x66 /* 'f' */ :
+		case 0x67 /* 'g' */ :
+		case 0x68 /* 'h' */ :
+		case 0x69 /* 'i' */ :
+		case 0x6a /* 'j' */ :
+		case 0x6b /* 'k' */ :
+		case 0x6c /* 'l' */ :
+		case 0x6d /* 'm' */ :
+		case 0x6e /* 'n' */ :
+		case 0x6f /* 'o' */ :
+		case 0x70 /* 'p' */ :
+		case 0x71 /* 'q' */ :
+		case 0x72 /* 'r' */ :
+		case 0x73 /* 's' */ :
+		case 0x74 /* 't' */ :
+		case 0x75 /* 'u' */ :
+		case 0x76 /* 'v' */ :
+		case 0x77 /* 'w' */ :
+		case 0x78 /* 'x' */ :
+		case 0x79 /* 'y' */ :
+		case 0x7a /* 'z' */ :
 		{
-			matchRange(static_cast<unsigned char>('a'),static_cast<unsigned char>('z'));
+			matchRange('a','z');
 			break;
 		}
-		case static_cast<unsigned char>('A'):
-		case static_cast<unsigned char>('B'):
-		case static_cast<unsigned char>('C'):
-		case static_cast<unsigned char>('D'):
-		case static_cast<unsigned char>('E'):
-		case static_cast<unsigned char>('F'):
-		case static_cast<unsigned char>('G'):
-		case static_cast<unsigned char>('H'):
-		case static_cast<unsigned char>('I'):
-		case static_cast<unsigned char>('J'):
-		case static_cast<unsigned char>('K'):
-		case static_cast<unsigned char>('L'):
-		case static_cast<unsigned char>('M'):
-		case static_cast<unsigned char>('N'):
-		case static_cast<unsigned char>('O'):
-		case static_cast<unsigned char>('P'):
-		case static_cast<unsigned char>('Q'):
-		case static_cast<unsigned char>('R'):
-		case static_cast<unsigned char>('S'):
-		case static_cast<unsigned char>('T'):
-		case static_cast<unsigned char>('U'):
-		case static_cast<unsigned char>('V'):
-		case static_cast<unsigned char>('W'):
-		case static_cast<unsigned char>('X'):
-		case static_cast<unsigned char>('Y'):
-		case static_cast<unsigned char>('Z'):
+		case 0x41 /* 'A' */ :
+		case 0x42 /* 'B' */ :
+		case 0x43 /* 'C' */ :
+		case 0x44 /* 'D' */ :
+		case 0x45 /* 'E' */ :
+		case 0x46 /* 'F' */ :
+		case 0x47 /* 'G' */ :
+		case 0x48 /* 'H' */ :
+		case 0x49 /* 'I' */ :
+		case 0x4a /* 'J' */ :
+		case 0x4b /* 'K' */ :
+		case 0x4c /* 'L' */ :
+		case 0x4d /* 'M' */ :
+		case 0x4e /* 'N' */ :
+		case 0x4f /* 'O' */ :
+		case 0x50 /* 'P' */ :
+		case 0x51 /* 'Q' */ :
+		case 0x52 /* 'R' */ :
+		case 0x53 /* 'S' */ :
+		case 0x54 /* 'T' */ :
+		case 0x55 /* 'U' */ :
+		case 0x56 /* 'V' */ :
+		case 0x57 /* 'W' */ :
+		case 0x58 /* 'X' */ :
+		case 0x59 /* 'Y' */ :
+		case 0x5a /* 'Z' */ :
 		{
-			matchRange(static_cast<unsigned char>('A'),static_cast<unsigned char>('Z'));
+			matchRange('A','Z');
 			break;
 		}
-		case static_cast<unsigned char>('_'):
+		case 0x5f /* '_' */ :
 		{
-			match(static_cast<unsigned char>('_'));
+			match('_' /* charlit */ );
 			break;
 		}
-		case static_cast<unsigned char>('0'):
-		case static_cast<unsigned char>('1'):
-		case static_cast<unsigned char>('2'):
-		case static_cast<unsigned char>('3'):
-		case static_cast<unsigned char>('4'):
-		case static_cast<unsigned char>('5'):
-		case static_cast<unsigned char>('6'):
-		case static_cast<unsigned char>('7'):
-		case static_cast<unsigned char>('8'):
-		case static_cast<unsigned char>('9'):
+		case 0x30 /* '0' */ :
+		case 0x31 /* '1' */ :
+		case 0x32 /* '2' */ :
+		case 0x33 /* '3' */ :
+		case 0x34 /* '4' */ :
+		case 0x35 /* '5' */ :
+		case 0x36 /* '6' */ :
+		case 0x37 /* '7' */ :
+		case 0x38 /* '8' */ :
+		case 0x39 /* '9' */ :
 		{
-			matchRange(static_cast<unsigned char>('0'),static_cast<unsigned char>('9'));
+			matchRange('0','9');
 			break;
 		}
 		default:
@@ -868,15 +868,15 @@ void EsterelLexer::mID(bool _createToken) {
   itself), which collides with the lookahead set for the single-period rule.
  */
 void EsterelLexer::mNumber(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = Number;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	{ // ( ... )+
 	int _cnt310=0;
 	for (;;) {
-		if (((LA(1) >= static_cast<unsigned char>('0') && LA(1) <= static_cast<unsigned char>('9')))) {
-			matchRange(static_cast<unsigned char>('0'),static_cast<unsigned char>('9'));
+		if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
+			matchRange('0','9');
 		}
 		else {
 			if ( _cnt310>=1 ) { goto _loop310; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
@@ -887,12 +887,12 @@ void EsterelLexer::mNumber(bool _createToken) {
 	_loop310:;
 	}  // ( ... )+
 	{
-	if ((LA(1) == static_cast<unsigned char>('.'))) {
-		match(static_cast<unsigned char>('.'));
+	if ((LA(1) == 0x2e /* '.' */ )) {
+		match('.' /* charlit */ );
 		{ // ( ... )*
 		for (;;) {
-			if (((LA(1) >= static_cast<unsigned char>('0') && LA(1) <= static_cast<unsigned char>('9')))) {
-				matchRange(static_cast<unsigned char>('0'),static_cast<unsigned char>('9'));
+			if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
+				matchRange('0','9');
 			}
 			else {
 				goto _loop313;
@@ -902,7 +902,7 @@ void EsterelLexer::mNumber(bool _createToken) {
 		_loop313:;
 		} // ( ... )*
 		{
-		if ((LA(1) == static_cast<unsigned char>('E') || LA(1) == static_cast<unsigned char>('e'))) {
+		if ((LA(1) == 0x45 /* 'E' */  || LA(1) == 0x65 /* 'e' */ )) {
 			mExponent(false);
 		}
 		else {
@@ -910,17 +910,17 @@ void EsterelLexer::mNumber(bool _createToken) {
 		
 		}
 		{
-		if ((LA(1) == static_cast<unsigned char>('F') || LA(1) == static_cast<unsigned char>('f'))) {
+		if ((LA(1) == 0x46 /* 'F' */  || LA(1) == 0x66 /* 'f' */ )) {
 			{
 			switch ( LA(1)) {
-			case static_cast<unsigned char>('f'):
+			case 0x66 /* 'f' */ :
 			{
-				match(static_cast<unsigned char>('f'));
+				match('f' /* charlit */ );
 				break;
 			}
-			case static_cast<unsigned char>('F'):
+			case 0x46 /* 'F' */ :
 			{
-				match(static_cast<unsigned char>('F'));
+				match('F' /* charlit */ );
 				break;
 			}
 			default:
@@ -963,20 +963,20 @@ void EsterelLexer::mNumber(bool _createToken) {
 }
 
 void EsterelLexer::mExponent(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = Exponent;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	{
 	switch ( LA(1)) {
-	case static_cast<unsigned char>('e'):
+	case 0x65 /* 'e' */ :
 	{
-		match(static_cast<unsigned char>('e'));
+		match('e' /* charlit */ );
 		break;
 	}
-	case static_cast<unsigned char>('E'):
+	case 0x45 /* 'E' */ :
 	{
-		match(static_cast<unsigned char>('E'));
+		match('E' /* charlit */ );
 		break;
 	}
 	default:
@@ -987,26 +987,26 @@ void EsterelLexer::mExponent(bool _createToken) {
 	}
 	{
 	switch ( LA(1)) {
-	case static_cast<unsigned char>('+'):
+	case 0x2b /* '+' */ :
 	{
-		match(static_cast<unsigned char>('+'));
+		match('+' /* charlit */ );
 		break;
 	}
-	case static_cast<unsigned char>('-'):
+	case 0x2d /* '-' */ :
 	{
-		match(static_cast<unsigned char>('-'));
+		match('-' /* charlit */ );
 		break;
 	}
-	case static_cast<unsigned char>('0'):
-	case static_cast<unsigned char>('1'):
-	case static_cast<unsigned char>('2'):
-	case static_cast<unsigned char>('3'):
-	case static_cast<unsigned char>('4'):
-	case static_cast<unsigned char>('5'):
-	case static_cast<unsigned char>('6'):
-	case static_cast<unsigned char>('7'):
-	case static_cast<unsigned char>('8'):
-	case static_cast<unsigned char>('9'):
+	case 0x30 /* '0' */ :
+	case 0x31 /* '1' */ :
+	case 0x32 /* '2' */ :
+	case 0x33 /* '3' */ :
+	case 0x34 /* '4' */ :
+	case 0x35 /* '5' */ :
+	case 0x36 /* '6' */ :
+	case 0x37 /* '7' */ :
+	case 0x38 /* '8' */ :
+	case 0x39 /* '9' */ :
 	{
 		break;
 	}
@@ -1019,8 +1019,8 @@ void EsterelLexer::mExponent(bool _createToken) {
 	{ // ( ... )+
 	int _cnt327=0;
 	for (;;) {
-		if (((LA(1) >= static_cast<unsigned char>('0') && LA(1) <= static_cast<unsigned char>('9')))) {
-			matchRange(static_cast<unsigned char>('0'),static_cast<unsigned char>('9'));
+		if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
+			matchRange('0','9');
 		}
 		else {
 			if ( _cnt327>=1 ) { goto _loop327; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
@@ -1039,16 +1039,16 @@ void EsterelLexer::mExponent(bool _createToken) {
 }
 
 void EsterelLexer::mFractionalNumber(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = FractionalNumber;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('.'));
+	match('.' /* charlit */ );
 	{ // ( ... )+
 	int _cnt319=0;
 	for (;;) {
-		if (((LA(1) >= static_cast<unsigned char>('0') && LA(1) <= static_cast<unsigned char>('9')))) {
-			matchRange(static_cast<unsigned char>('0'),static_cast<unsigned char>('9'));
+		if (((LA(1) >= 0x30 /* '0' */  && LA(1) <= 0x39 /* '9' */ ))) {
+			matchRange('0','9');
 		}
 		else {
 			if ( _cnt319>=1 ) { goto _loop319; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());}
@@ -1059,7 +1059,7 @@ void EsterelLexer::mFractionalNumber(bool _createToken) {
 	_loop319:;
 	}  // ( ... )+
 	{
-	if ((LA(1) == static_cast<unsigned char>('E') || LA(1) == static_cast<unsigned char>('e'))) {
+	if ((LA(1) == 0x45 /* 'E' */  || LA(1) == 0x65 /* 'e' */ )) {
 		mExponent(false);
 	}
 	else {
@@ -1067,17 +1067,17 @@ void EsterelLexer::mFractionalNumber(bool _createToken) {
 	
 	}
 	{
-	if ((LA(1) == static_cast<unsigned char>('F') || LA(1) == static_cast<unsigned char>('f'))) {
+	if ((LA(1) == 0x46 /* 'F' */  || LA(1) == 0x66 /* 'f' */ )) {
 		{
 		switch ( LA(1)) {
-		case static_cast<unsigned char>('f'):
+		case 0x66 /* 'f' */ :
 		{
-			match(static_cast<unsigned char>('f'));
+			match('f' /* charlit */ );
 			break;
 		}
-		case static_cast<unsigned char>('F'):
+		case 0x46 /* 'F' */ :
 		{
-			match(static_cast<unsigned char>('F'));
+			match('F' /* charlit */ );
 			break;
 		}
 		default:
@@ -1116,21 +1116,21 @@ void EsterelLexer::mFractionalNumber(bool _createToken) {
       "This is a constant with ""double quotes""" 
 */
 void EsterelLexer::mStringConstant(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = StringConstant;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	_saveIndex=text.length();
-	match(static_cast<unsigned char>('"'));
+	_saveIndex = text.length();
+	match('\"' /* charlit */ );
 	text.erase(_saveIndex);
 	{ // ( ... )*
 	for (;;) {
-		if ((LA(1) == static_cast<unsigned char>('"')) && (LA(2) == static_cast<unsigned char>('"'))) {
+		if ((LA(1) == 0x22 /* '\"' */ ) && (LA(2) == 0x22 /* '\"' */ )) {
 			{
-			_saveIndex=text.length();
-			match(static_cast<unsigned char>('"'));
+			_saveIndex = text.length();
+			match('\"' /* charlit */ );
 			text.erase(_saveIndex);
-			match(static_cast<unsigned char>('"'));
+			match('\"' /* charlit */ );
 			}
 		}
 		else if ((_tokenSet_0.member(LA(1)))) {
@@ -1145,8 +1145,8 @@ void EsterelLexer::mStringConstant(bool _createToken) {
 	}
 	_loop332:;
 	} // ( ... )*
-	_saveIndex=text.length();
-	match(static_cast<unsigned char>('"'));
+	_saveIndex = text.length();
+	match('\"' /* charlit */ );
 	text.erase(_saveIndex);
 	if ( _createToken && _token==ANTLR_USE_NAMESPACE(antlr)nullToken && _ttype!=ANTLR_USE_NAMESPACE(antlr)Token::SKIP ) {
 	   _token = makeToken(_ttype);
@@ -1157,27 +1157,27 @@ void EsterelLexer::mStringConstant(bool _createToken) {
 }
 
 void EsterelLexer::mWhitespace(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = Whitespace;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	{ // ( ... )+
 	int _cnt335=0;
 	for (;;) {
 		switch ( LA(1)) {
-		case static_cast<unsigned char>(' '):
+		case 0x20 /* ' ' */ :
 		{
-			match(static_cast<unsigned char>(' '));
+			match(' ' /* charlit */ );
 			break;
 		}
-		case static_cast<unsigned char>('\t'):
+		case 0x9 /* '\t' */ :
 		{
-			match(static_cast<unsigned char>('\t'));
+			match('\t' /* charlit */ );
 			break;
 		}
-		case static_cast<unsigned char>('\14'):
+		case 0xc /* '\14' */ :
 		{
-			match(static_cast<unsigned char>('\14'));
+			match('\14' /* charlit */ );
 			break;
 		}
 		default:
@@ -1203,19 +1203,19 @@ void EsterelLexer::mWhitespace(bool _createToken) {
 }
 
 void EsterelLexer::mNewline(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = Newline;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
 	{
-	if ((LA(1) == static_cast<unsigned char>('\r')) && (LA(2) == static_cast<unsigned char>('\n'))) {
+	if ((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ )) {
 		match("\r\n");
 	}
-	else if ((LA(1) == static_cast<unsigned char>('\n'))) {
-		match(static_cast<unsigned char>('\n'));
+	else if ((LA(1) == 0xa /* '\n' */ )) {
+		match('\n' /* charlit */ );
 	}
-	else if ((LA(1) == static_cast<unsigned char>('\r')) && (true)) {
-		match(static_cast<unsigned char>('\r'));
+	else if ((LA(1) == 0xd /* '\r' */ ) && (true)) {
+		match('\r' /* charlit */ );
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltForCharException(LA(1), getFilename(), getLine(), getColumn());
@@ -1241,20 +1241,20 @@ void EsterelLexer::mNewline(bool _createToken) {
   Single-line comments start with %
 */
 void EsterelLexer::mComment(bool _createToken) {
-	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; int _begin=text.length();
+	int _ttype; ANTLR_USE_NAMESPACE(antlr)RefToken _token; ANTLR_USE_NAMESPACE(std)string::size_type _begin = text.length();
 	_ttype = Comment;
-	int _saveIndex;
+	ANTLR_USE_NAMESPACE(std)string::size_type _saveIndex;
 	
-	match(static_cast<unsigned char>('%'));
+	match('%' /* charlit */ );
 	{
 	bool synPredMatched341 = false;
-	if (((LA(1) == static_cast<unsigned char>('{')) && ((LA(2) >= static_cast<unsigned char>('\3') && LA(2) <= static_cast<unsigned char>('\377'))))) {
+	if (((LA(1) == 0x7b /* '{' */ ) && ((LA(2) >= 0x3 /* '\3' */  && LA(2) <= 0xff)))) {
 		int _m341 = mark();
 		synPredMatched341 = true;
 		inputState->guessing++;
 		try {
 			{
-			match(static_cast<unsigned char>('{'));
+			match('{' /* charlit */ );
 			}
 		}
 		catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& pe) {
@@ -1264,22 +1264,22 @@ void EsterelLexer::mComment(bool _createToken) {
 		inputState->guessing--;
 	}
 	if ( synPredMatched341 ) {
-		match(static_cast<unsigned char>('{'));
+		match('{' /* charlit */ );
 		{ // ( ... )*
 		for (;;) {
 			// nongreedy exit test
-			if ((LA(1) == static_cast<unsigned char>('}')) && (LA(2) == static_cast<unsigned char>('%'))) goto _loop347;
-			if (((LA(1) >= static_cast<unsigned char>('\3') && LA(1) <= static_cast<unsigned char>('\377'))) && ((LA(2) >= static_cast<unsigned char>('\3') && LA(2) <= static_cast<unsigned char>('\377')))) {
+			if ((LA(1) == 0x7d /* '}' */ ) && (LA(2) == 0x25 /* '%' */ )) goto _loop347;
+			if (((LA(1) >= 0x3 /* '\3' */  && LA(1) <= 0xff)) && ((LA(2) >= 0x3 /* '\3' */  && LA(2) <= 0xff))) {
 				{
 				bool synPredMatched345 = false;
-				if (((LA(1) == static_cast<unsigned char>('\r')) && (LA(2) == static_cast<unsigned char>('\n')))) {
+				if (((LA(1) == 0xd /* '\r' */ ) && (LA(2) == 0xa /* '\n' */ ))) {
 					int _m345 = mark();
 					synPredMatched345 = true;
 					inputState->guessing++;
 					try {
 						{
-						match(static_cast<unsigned char>('\r'));
-						match(static_cast<unsigned char>('\n'));
+						match('\r' /* charlit */ );
+						match('\n' /* charlit */ );
 						}
 					}
 					catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& pe) {
@@ -1289,24 +1289,24 @@ void EsterelLexer::mComment(bool _createToken) {
 					inputState->guessing--;
 				}
 				if ( synPredMatched345 ) {
-					match(static_cast<unsigned char>('\r'));
-					match(static_cast<unsigned char>('\n'));
+					match('\r' /* charlit */ );
+					match('\n' /* charlit */ );
 					if ( inputState->guessing==0 ) {
 #line 855 "esterel.g"
 						newline();
 #line 1298 "EsterelLexer.cpp"
 					}
 				}
-				else if ((LA(1) == static_cast<unsigned char>('\r')) && ((LA(2) >= static_cast<unsigned char>('\3') && LA(2) <= static_cast<unsigned char>('\377')))) {
-					match(static_cast<unsigned char>('\r'));
+				else if ((LA(1) == 0xd /* '\r' */ ) && ((LA(2) >= 0x3 /* '\3' */  && LA(2) <= 0xff))) {
+					match('\r' /* charlit */ );
 					if ( inputState->guessing==0 ) {
 #line 856 "esterel.g"
 						newline();
 #line 1306 "EsterelLexer.cpp"
 					}
 				}
-				else if ((LA(1) == static_cast<unsigned char>('\n'))) {
-					match(static_cast<unsigned char>('\n'));
+				else if ((LA(1) == 0xa /* '\n' */ )) {
+					match('\n' /* charlit */ );
 					if ( inputState->guessing==0 ) {
 #line 857 "esterel.g"
 						newline();
@@ -1333,12 +1333,12 @@ void EsterelLexer::mComment(bool _createToken) {
 		} // ( ... )*
 		match("}%");
 	}
-	else if (((LA(1) >= static_cast<unsigned char>('\3') && LA(1) <= static_cast<unsigned char>('\377'))) && (true)) {
+	else if (((LA(1) >= 0x3 /* '\3' */  && LA(1) <= 0xff)) && (true)) {
 		{ // ( ... )*
 		for (;;) {
 			if ((_tokenSet_2.member(LA(1)))) {
 				{
-				matchNot(static_cast<unsigned char>('\n'));
+				matchNot('\n' /* charlit */ );
 				}
 			}
 			else {
@@ -1348,7 +1348,7 @@ void EsterelLexer::mComment(bool _createToken) {
 		}
 		_loop350:;
 		} // ( ... )*
-		match(static_cast<unsigned char>('\n'));
+		match('\n' /* charlit */ );
 		if ( inputState->guessing==0 ) {
 #line 862 "esterel.g"
 			newline();
@@ -1375,51 +1375,24 @@ void EsterelLexer::mComment(bool _createToken) {
 
 
 const unsigned long EsterelLexer::_tokenSet_0_data_[] = { 4294966264UL, 4294967291UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// NULL_TREE_LOOKAHEAD SIGS VARS TYPES DECLS TRAPS SEQUENCE CASE DELAY 
-// DOWATCHING DOUPTO CDECL TDECL FDECL PDECL TADECL VDECLS VDECL SDECL 
-// CALL RUN TRENAME CRENAME SRENAME TARENAME FRENAME PRENAME Integer FloatConst 
-// DoubleConst COLON "end" PERIOD "type" COMMA SEMICOLON "constant" EQUALS 
-// ID "function" LPAREN RPAREN "procedure" "task" "input" "output" "inputoutput" 
-// "return" COLEQUALS "combine" "with" PLUS STAR "or" "and" "sensor" "relation" 
-// IMPLIES POUND "not" NEQUAL LESSTHAN GREATERTHAN LEQUAL GEQUAL DASH SLASH 
-// "mod" QUESTION "pre" DQUESTION "true" "false" "immediate" LBRACKET RBRACKET 
-// PARALLEL "nothing" "pause" "halt" "emit" "sustain" "call" "present" 
-// "then" "else" "case" "do" "if" "elsif" "positive" "repeat" "times" "abort" 
-// "when" "weak" "await" "loop" "each" "every" "suspend" "trap" "in" "exit" 
-// "handle" "exec" "signal" "var" "run" "copymodule" "watching" "timeout" 
-// "upto" StringConstant Number FractionalNumber Exponent Whitespace Newline 
-// Comment 
+// 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xb 0xc 0xd 0xe 0xf 0x10 0x11 0x12 0x13 
+// 0x14 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f   ! # $ 
+// % & \' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F 
+// G H I J K L M N O P Q R S T U V W X Y Z [ 0x5c ] ^ _ ` a b c d e f g 
+// h i j k l m n o p q r s t u v w x y z { | 
 const ANTLR_USE_NAMESPACE(antlr)BitSet EsterelLexer::_tokenSet_0(_tokenSet_0_data_,16);
 const unsigned long EsterelLexer::_tokenSet_1_data_[] = { 4294958072UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// NULL_TREE_LOOKAHEAD SIGS VARS TYPES DECLS TRAPS SEQUENCE CASE DELAY 
-// DOUPTO CDECL TDECL FDECL PDECL TADECL VDECLS VDECL SDECL CALL RUN TRENAME 
-// CRENAME SRENAME TARENAME FRENAME PRENAME Integer FloatConst DoubleConst 
-// "module" COLON "end" PERIOD "type" COMMA SEMICOLON "constant" EQUALS 
-// ID "function" LPAREN RPAREN "procedure" "task" "input" "output" "inputoutput" 
-// "return" COLEQUALS "combine" "with" PLUS STAR "or" "and" "sensor" "relation" 
-// IMPLIES POUND "not" NEQUAL LESSTHAN GREATERTHAN LEQUAL GEQUAL DASH SLASH 
-// "mod" QUESTION "pre" DQUESTION "true" "false" "immediate" LBRACKET RBRACKET 
-// PARALLEL "nothing" "pause" "halt" "emit" "sustain" "call" "present" 
-// "then" "else" "case" "do" "if" "elsif" "positive" "repeat" "times" "abort" 
-// "when" "weak" "await" "loop" "each" "every" "suspend" "trap" "in" "exit" 
-// "handle" "exec" "signal" "var" "run" "copymodule" "watching" "timeout" 
-// "upto" StringConstant Number FractionalNumber Exponent Whitespace Newline 
-// Comment 
+// 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xb 0xc 0xe 0xf 0x10 0x11 0x12 0x13 0x14 
+// 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f   ! \" # $ % 
+// & \' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E F G 
+// H I J K L M N O P Q R S T U V W X Y Z [ 0x5c ] ^ _ ` a b c d e f g h 
+// i j k l m n o p q r s t u v w x y z { | 
 const ANTLR_USE_NAMESPACE(antlr)BitSet EsterelLexer::_tokenSet_1(_tokenSet_1_data_,16);
 const unsigned long EsterelLexer::_tokenSet_2_data_[] = { 4294966264UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 4294967295UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL, 0UL };
-// NULL_TREE_LOOKAHEAD SIGS VARS TYPES DECLS TRAPS SEQUENCE CASE DELAY 
-// DOWATCHING DOUPTO CDECL TDECL FDECL PDECL TADECL VDECLS VDECL SDECL 
-// CALL RUN TRENAME CRENAME SRENAME TARENAME FRENAME PRENAME Integer FloatConst 
-// DoubleConst "module" COLON "end" PERIOD "type" COMMA SEMICOLON "constant" 
-// EQUALS ID "function" LPAREN RPAREN "procedure" "task" "input" "output" 
-// "inputoutput" "return" COLEQUALS "combine" "with" PLUS STAR "or" "and" 
-// "sensor" "relation" IMPLIES POUND "not" NEQUAL LESSTHAN GREATERTHAN 
-// LEQUAL GEQUAL DASH SLASH "mod" QUESTION "pre" DQUESTION "true" "false" 
-// "immediate" LBRACKET RBRACKET PARALLEL "nothing" "pause" "halt" "emit" 
-// "sustain" "call" "present" "then" "else" "case" "do" "if" "elsif" "positive" 
-// "repeat" "times" "abort" "when" "weak" "await" "loop" "each" "every" 
-// "suspend" "trap" "in" "exit" "handle" "exec" "signal" "var" "run" "copymodule" 
-// "watching" "timeout" "upto" StringConstant Number FractionalNumber Exponent 
-// Whitespace Newline Comment 
+// 0x3 0x4 0x5 0x6 0x7 0x8 0x9 0xb 0xc 0xd 0xe 0xf 0x10 0x11 0x12 0x13 
+// 0x14 0x15 0x16 0x17 0x18 0x19 0x1a 0x1b 0x1c 0x1d 0x1e 0x1f   ! \" # 
+// $ % & \' ( ) * + , - . / 0 1 2 3 4 5 6 7 8 9 : ; < = > ? @ A B C D E 
+// F G H I J K L M N O P Q R S T U V W X Y Z [ 0x5c ] ^ _ ` a b c d e f 
+// g h i j k l m n o p q r s t u v w x y z { | 
 const ANTLR_USE_NAMESPACE(antlr)BitSet EsterelLexer::_tokenSet_2(_tokenSet_2_data_,16);
 

--- a/src/EsterelLexer.hpp
+++ b/src/EsterelLexer.hpp
@@ -2,7 +2,7 @@
 #define INC_EsterelLexer_hpp_
 
 #include <antlr/config.hpp>
-/* $ANTLR 2.7.2: "esterel.g" -> "EsterelLexer.hpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "esterel.g" -> "EsterelLexer.hpp"$ */
 #include <antlr/CommonToken.hpp>
 #include <antlr/InputBuffer.hpp>
 #include <antlr/BitSet.hpp>
@@ -13,7 +13,7 @@
 #include "LineAST.hpp"
 
 #line 16 "EsterelLexer.hpp"
-class EsterelLexer : public ANTLR_USE_NAMESPACE(antlr)CharScanner, public EsterelTokenTypes
+class CUSTOM_API EsterelLexer : public ANTLR_USE_NAMESPACE(antlr)CharScanner, public EsterelTokenTypes
 {
 #line 1 "esterel.g"
 #line 20 "EsterelLexer.hpp"

--- a/src/EsterelParser.cpp
+++ b/src/EsterelParser.cpp
@@ -1,4 +1,4 @@
-/* $ANTLR 2.7.2: "esterel.g" -> "EsterelParser.cpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "esterel.g" -> "EsterelParser.cpp"$ */
 #include "EsterelParser.hpp"
 #include <antlr/NoViableAltException.hpp>
 #include <antlr/SemanticException.hpp>
@@ -31,9 +31,9 @@ EsterelParser::EsterelParser(const ANTLR_USE_NAMESPACE(antlr)ParserSharedInputSt
 }
 
 void EsterelParser::file() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST file_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST file_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{ // ( ... )+
 	int _cnt3=0;
@@ -41,7 +41,7 @@ void EsterelParser::file() {
 		if ((LA(1) == LITERAL_module)) {
 			module();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -53,33 +53,33 @@ void EsterelParser::file() {
 	_loop3:;
 	}  // ( ... )+
 	match(ANTLR_USE_NAMESPACE(antlr)Token::EOF_TYPE);
-	file_AST = static_cast<RefLineAST>(currentAST.root);
+	file_AST = RefLineAST(currentAST.root);
 	returnAST = file_AST;
 }
 
 void EsterelParser::module() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST module_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST module_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp2_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp2_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp2_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp2_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp2_AST));
 	}
 	match(LITERAL_module);
 	moduleIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(COLON);
 	declarations();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -100,36 +100,36 @@ void EsterelParser::module() {
 	}
 	}
 	}
-	module_AST = static_cast<RefLineAST>(currentAST.root);
+	module_AST = RefLineAST(currentAST.root);
 	returnAST = module_AST;
 }
 
 void EsterelParser::moduleIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST moduleIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST moduleIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp7_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp7_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp7_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp7_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp7_AST));
 	}
 	match(ID);
-	moduleIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	moduleIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = moduleIdentifier_AST;
 }
 
 void EsterelParser::declarations() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST declarations_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST declarations_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{ // ( ... )*
 	for (;;) {
 		if ((_tokenSet_0.member(LA(1)))) {
 			interfaceDecls();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -142,28 +142,28 @@ void EsterelParser::declarations() {
 	if ( inputState->guessing==0 ) {
 		declarations_AST = RefLineAST(currentAST.root);
 #line 88 "esterel.g"
-		declarations_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(DECLS,"decls")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(declarations_AST))));
+		declarations_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(DECLS,"decls")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(declarations_AST))));
 #line 147 "EsterelParser.cpp"
 		currentAST.root = declarations_AST;
-		if ( declarations_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			declarations_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( declarations_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			declarations_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = declarations_AST->getFirstChild();
 		else
 			currentAST.child = declarations_AST;
 		currentAST.advanceChildToEnd();
 	}
-	declarations_AST = static_cast<RefLineAST>(currentAST.root);
+	declarations_AST = RefLineAST(currentAST.root);
 	returnAST = declarations_AST;
 }
 
 void EsterelParser::statement() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST statement_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST statement_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	sequence();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -171,7 +171,7 @@ void EsterelParser::statement() {
 			match(PARALLEL);
 			sequence();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -185,71 +185,71 @@ void EsterelParser::statement() {
 		statement_AST = RefLineAST(currentAST.root);
 #line 366 "esterel.g"
 		if (statement_AST && statement_AST->getNextSibling()) {
-		statement_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(PARALLEL,"||")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(statement_AST))));
+		statement_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(PARALLEL,"||")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(statement_AST))));
 		}
 		
 #line 192 "EsterelParser.cpp"
 		currentAST.root = statement_AST;
-		if ( statement_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			statement_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( statement_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			statement_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = statement_AST->getFirstChild();
 		else
 			currentAST.child = statement_AST;
 		currentAST.advanceChildToEnd();
 	}
-	statement_AST = static_cast<RefLineAST>(currentAST.root);
+	statement_AST = RefLineAST(currentAST.root);
 	returnAST = statement_AST;
 }
 
 void EsterelParser::interfaceDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST interfaceDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST interfaceDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_type:
 	{
 		typeDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_constant:
 	{
 		constantDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_function:
 	{
 		functionDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_procedure:
 	{
 		procedureDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_task:
 	{
 		taskDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_input:
@@ -259,27 +259,27 @@ void EsterelParser::interfaceDecls() {
 	{
 		interfacesignalDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_sensor:
 	{
 		sensorDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_relation:
 	{
 		relationDecls();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		interfaceDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfaceDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -291,19 +291,19 @@ void EsterelParser::interfaceDecls() {
 }
 
 void EsterelParser::typeDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST typeDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp9_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp9_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp9_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp9_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp9_AST));
 	}
 	match(LITERAL_type);
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -311,7 +311,7 @@ void EsterelParser::typeDecls() {
 			match(COMMA);
 			typeIdentifier();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -322,24 +322,24 @@ void EsterelParser::typeDecls() {
 	_loop12:;
 	} // ( ... )*
 	match(SEMICOLON);
-	typeDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	typeDecls_AST = RefLineAST(currentAST.root);
 	returnAST = typeDecls_AST;
 }
 
 void EsterelParser::constantDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp12_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp12_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp12_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp12_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp12_AST));
 	}
 	match(LITERAL_constant);
 	constantDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -347,7 +347,7 @@ void EsterelParser::constantDecls() {
 			match(COMMA);
 			constantDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -358,24 +358,24 @@ void EsterelParser::constantDecls() {
 	_loop15:;
 	} // ( ... )*
 	match(SEMICOLON);
-	constantDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	constantDecls_AST = RefLineAST(currentAST.root);
 	returnAST = constantDecls_AST;
 }
 
 void EsterelParser::functionDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST functionDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp15_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp15_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp15_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp15_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp15_AST));
 	}
 	match(LITERAL_function);
 	functionDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -383,7 +383,7 @@ void EsterelParser::functionDecls() {
 			match(COMMA);
 			functionDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -394,24 +394,24 @@ void EsterelParser::functionDecls() {
 	_loop25:;
 	} // ( ... )*
 	match(SEMICOLON);
-	functionDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	functionDecls_AST = RefLineAST(currentAST.root);
 	returnAST = functionDecls_AST;
 }
 
 void EsterelParser::procedureDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST procedureDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp18_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp18_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp18_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp18_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp18_AST));
 	}
 	match(LITERAL_procedure);
 	procedureDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -419,7 +419,7 @@ void EsterelParser::procedureDecls() {
 			match(COMMA);
 			procedureDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -430,24 +430,24 @@ void EsterelParser::procedureDecls() {
 	_loop33:;
 	} // ( ... )*
 	match(SEMICOLON);
-	procedureDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	procedureDecls_AST = RefLineAST(currentAST.root);
 	returnAST = procedureDecls_AST;
 }
 
 void EsterelParser::taskDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST taskDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp21_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp21_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp21_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp21_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp21_AST));
 	}
 	match(LITERAL_task);
 	taskDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -455,7 +455,7 @@ void EsterelParser::taskDecls() {
 			match(COMMA);
 			taskDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -466,7 +466,7 @@ void EsterelParser::taskDecls() {
 	_loop37:;
 	} // ( ... )*
 	match(SEMICOLON);
-	taskDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	taskDecls_AST = RefLineAST(currentAST.root);
 	returnAST = taskDecls_AST;
 }
 
@@ -475,22 +475,22 @@ void EsterelParser::taskDecls() {
     but only constants are permitted in interface signals.
 */
 void EsterelParser::interfacesignalDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST interfacesignalDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST interfacesignalDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_input:
 	{
-		RefLineAST tmp24_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp24_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp24_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp24_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp24_AST));
 		}
 		match(LITERAL_input);
 		signalDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -498,7 +498,7 @@ void EsterelParser::interfacesignalDecls() {
 				match(COMMA);
 				signalDecl();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -509,20 +509,20 @@ void EsterelParser::interfacesignalDecls() {
 		_loop41:;
 		} // ( ... )*
 		match(SEMICOLON);
-		interfacesignalDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfacesignalDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_output:
 	{
-		RefLineAST tmp27_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp27_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp27_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp27_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp27_AST));
 		}
 		match(LITERAL_output);
 		signalDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -530,7 +530,7 @@ void EsterelParser::interfacesignalDecls() {
 				match(COMMA);
 				signalDecl();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -541,20 +541,20 @@ void EsterelParser::interfacesignalDecls() {
 		_loop43:;
 		} // ( ... )*
 		match(SEMICOLON);
-		interfacesignalDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfacesignalDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_inputoutput:
 	{
-		RefLineAST tmp30_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp30_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp30_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp30_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp30_AST));
 		}
 		match(LITERAL_inputoutput);
 		signalDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -562,7 +562,7 @@ void EsterelParser::interfacesignalDecls() {
 				match(COMMA);
 				signalDecl();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -573,20 +573,20 @@ void EsterelParser::interfacesignalDecls() {
 		_loop45:;
 		} // ( ... )*
 		match(SEMICOLON);
-		interfacesignalDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfacesignalDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_return:
 	{
-		RefLineAST tmp33_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp33_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp33_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp33_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp33_AST));
 		}
 		match(LITERAL_return);
 		signalDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -594,7 +594,7 @@ void EsterelParser::interfacesignalDecls() {
 				match(COMMA);
 				signalDecl();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -605,7 +605,7 @@ void EsterelParser::interfacesignalDecls() {
 		_loop47:;
 		} // ( ... )*
 		match(SEMICOLON);
-		interfacesignalDecls_AST = static_cast<RefLineAST>(currentAST.root);
+		interfacesignalDecls_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -617,19 +617,19 @@ void EsterelParser::interfacesignalDecls() {
 }
 
 void EsterelParser::sensorDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sensorDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sensorDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp36_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp36_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp36_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp36_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp36_AST));
 	}
 	match(LITERAL_sensor);
 	sensorDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -637,7 +637,7 @@ void EsterelParser::sensorDecls() {
 			match(COMMA);
 			sensorDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -648,24 +648,24 @@ void EsterelParser::sensorDecls() {
 	_loop60:;
 	} // ( ... )*
 	match(SEMICOLON);
-	sensorDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	sensorDecls_AST = RefLineAST(currentAST.root);
 	returnAST = sensorDecls_AST;
 }
 
 void EsterelParser::relationDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST relationDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST relationDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp39_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp39_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp39_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp39_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp39_AST));
 	}
 	match(LITERAL_relation);
 	relationDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -673,7 +673,7 @@ void EsterelParser::relationDecls() {
 			match(COMMA);
 			relationDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -684,35 +684,35 @@ void EsterelParser::relationDecls() {
 	_loop65:;
 	} // ( ... )*
 	match(SEMICOLON);
-	relationDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	relationDecls_AST = RefLineAST(currentAST.root);
 	returnAST = relationDecls_AST;
 }
 
 void EsterelParser::typeIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST typeIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp42_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp42_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp42_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp42_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp42_AST));
 	}
 	match(ID);
-	typeIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	typeIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = typeIdentifier_AST;
 }
 
 void EsterelParser::constantDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	if ((LA(1) == ID) && (LA(2) == COLON || LA(2) == EQUALS)) {
 		constantIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{
 		switch ( LA(1)) {
@@ -720,7 +720,7 @@ void EsterelParser::constantDecl() {
 		{
 			constantInitializer();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -738,7 +738,7 @@ void EsterelParser::constantDecl() {
 	else if ((LA(1) == ID) && (LA(2) == COMMA)) {
 		identifierList();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 	}
 	else {
@@ -749,90 +749,90 @@ void EsterelParser::constantDecl() {
 	match(COLON);
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		constantDecl_AST = RefLineAST(currentAST.root);
 #line 118 "esterel.g"
-		constantDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CDECL,"cdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(constantDecl_AST))));
+		constantDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CDECL,"cdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(constantDecl_AST))));
 #line 759 "EsterelParser.cpp"
 		currentAST.root = constantDecl_AST;
-		if ( constantDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			constantDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( constantDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			constantDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = constantDecl_AST->getFirstChild();
 		else
 			currentAST.child = constantDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	constantDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	constantDecl_AST = RefLineAST(currentAST.root);
 	returnAST = constantDecl_AST;
 }
 
 void EsterelParser::constantIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp44_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp44_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp44_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp44_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp44_AST));
 	}
 	match(ID);
-	constantIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	constantIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = constantIdentifier_AST;
 }
 
 void EsterelParser::constantInitializer() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantInitializer_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantInitializer_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp45_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp45_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp45_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp45_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp45_AST));
 	}
 	match(EQUALS);
 	constantAtom();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	constantInitializer_AST = static_cast<RefLineAST>(currentAST.root);
+	constantInitializer_AST = RefLineAST(currentAST.root);
 	returnAST = constantInitializer_AST;
 }
 
 void EsterelParser::identifierList() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST identifierList_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST identifierList_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp46_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp46_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp46_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp46_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp46_AST));
 	}
 	match(ID);
-	RefLineAST tmp47_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp47_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp47_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp47_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp47_AST));
 	}
 	match(COMMA);
-	RefLineAST tmp48_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp48_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp48_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp48_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp48_AST));
 	}
 	match(ID);
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == COMMA)) {
 			match(COMMA);
-			RefLineAST tmp50_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp50_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp50_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp50_AST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp50_AST));
 			}
 			match(ID);
 		}
@@ -843,14 +843,14 @@ void EsterelParser::identifierList() {
 	}
 	_loop22:;
 	} // ( ... )*
-	identifierList_AST = static_cast<RefLineAST>(currentAST.root);
+	identifierList_AST = RefLineAST(currentAST.root);
 	returnAST = identifierList_AST;
 }
 
 void EsterelParser::constantAtom() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantAtom_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantAtom_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
@@ -860,9 +860,9 @@ void EsterelParser::constantAtom() {
 	{
 		constantLiteral();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constantAtom_AST = static_cast<RefLineAST>(currentAST.root);
+		constantAtom_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case Integer:
@@ -872,9 +872,9 @@ void EsterelParser::constantAtom() {
 	{
 		signedNumber();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constantAtom_AST = static_cast<RefLineAST>(currentAST.root);
+		constantAtom_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -886,59 +886,59 @@ void EsterelParser::constantAtom() {
 }
 
 void EsterelParser::functionDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST functionDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	functionIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	optTypeIdentifierList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(COLON);
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		functionDecl_AST = RefLineAST(currentAST.root);
 #line 137 "esterel.g"
-		functionDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(FDECL,"fdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(functionDecl_AST))));
+		functionDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(FDECL,"fdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(functionDecl_AST))));
 #line 911 "EsterelParser.cpp"
 		currentAST.root = functionDecl_AST;
-		if ( functionDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			functionDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( functionDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			functionDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = functionDecl_AST->getFirstChild();
 		else
 			currentAST.child = functionDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	functionDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	functionDecl_AST = RefLineAST(currentAST.root);
 	returnAST = functionDecl_AST;
 }
 
 void EsterelParser::functionIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST functionIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp52_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp52_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp52_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp52_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp52_AST));
 	}
 	match(ID);
-	functionIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	functionIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = functionIdentifier_AST;
 }
 
 void EsterelParser::optTypeIdentifierList() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST optTypeIdentifierList_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST optTypeIdentifierList_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LPAREN);
 	{
@@ -947,7 +947,7 @@ void EsterelParser::optTypeIdentifierList() {
 	{
 		typeIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -955,7 +955,7 @@ void EsterelParser::optTypeIdentifierList() {
 				match(COMMA);
 				typeIdentifier();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -981,126 +981,126 @@ void EsterelParser::optTypeIdentifierList() {
 	if ( inputState->guessing==0 ) {
 		optTypeIdentifierList_AST = RefLineAST(currentAST.root);
 #line 142 "esterel.g"
-		optTypeIdentifierList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TYPES,"types")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(optTypeIdentifierList_AST))));
+		optTypeIdentifierList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TYPES,"types")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(optTypeIdentifierList_AST))));
 #line 986 "EsterelParser.cpp"
 		currentAST.root = optTypeIdentifierList_AST;
-		if ( optTypeIdentifierList_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			optTypeIdentifierList_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( optTypeIdentifierList_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			optTypeIdentifierList_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = optTypeIdentifierList_AST->getFirstChild();
 		else
 			currentAST.child = optTypeIdentifierList_AST;
 		currentAST.advanceChildToEnd();
 	}
-	optTypeIdentifierList_AST = static_cast<RefLineAST>(currentAST.root);
+	optTypeIdentifierList_AST = RefLineAST(currentAST.root);
 	returnAST = optTypeIdentifierList_AST;
 }
 
 void EsterelParser::procedureDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST procedureDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	procedureIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	optTypeIdentifierList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	optTypeIdentifierList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		procedureDecl_AST = RefLineAST(currentAST.root);
 #line 153 "esterel.g"
-		procedureDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(PDECL,"pdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(procedureDecl_AST))));
+		procedureDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(PDECL,"pdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(procedureDecl_AST))));
 #line 1020 "EsterelParser.cpp"
 		currentAST.root = procedureDecl_AST;
-		if ( procedureDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			procedureDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( procedureDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			procedureDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = procedureDecl_AST->getFirstChild();
 		else
 			currentAST.child = procedureDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	procedureDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	procedureDecl_AST = RefLineAST(currentAST.root);
 	returnAST = procedureDecl_AST;
 }
 
 void EsterelParser::procedureIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST procedureIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp56_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp56_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp56_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp56_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp56_AST));
 	}
 	match(ID);
-	procedureIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	procedureIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = procedureIdentifier_AST;
 }
 
 void EsterelParser::taskDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST taskDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	taskIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	optTypeIdentifierList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	optTypeIdentifierList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		taskDecl_AST = RefLineAST(currentAST.root);
 #line 164 "esterel.g"
-		taskDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TADECL,"tdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(taskDecl_AST))));
+		taskDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TADECL,"tdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(taskDecl_AST))));
 #line 1069 "EsterelParser.cpp"
 		currentAST.root = taskDecl_AST;
-		if ( taskDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			taskDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( taskDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			taskDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = taskDecl_AST->getFirstChild();
 		else
 			currentAST.child = taskDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	taskDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	taskDecl_AST = RefLineAST(currentAST.root);
 	returnAST = taskDecl_AST;
 }
 
 void EsterelParser::taskIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST taskIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp57_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp57_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp57_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp57_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp57_AST));
 	}
 	match(ID);
-	taskIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	taskIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = taskIdentifier_AST;
 }
 
 void EsterelParser::signalDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -1119,7 +1119,7 @@ void EsterelParser::signalDecl() {
 		{
 			signalInitializer();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -1136,7 +1136,7 @@ void EsterelParser::signalDecl() {
 		match(COLON);
 		channelType();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -1145,7 +1145,7 @@ void EsterelParser::signalDecl() {
 		match(LPAREN);
 		channelType();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
 		break;
@@ -1159,28 +1159,28 @@ void EsterelParser::signalDecl() {
 	if ( inputState->guessing==0 ) {
 		signalDecl_AST = RefLineAST(currentAST.root);
 #line 192 "esterel.g"
-		signalDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(SDECL,"sdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(signalDecl_AST))));
+		signalDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(SDECL,"sdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(signalDecl_AST))));
 #line 1164 "EsterelParser.cpp"
 		currentAST.root = signalDecl_AST;
-		if ( signalDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			signalDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( signalDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			signalDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = signalDecl_AST->getFirstChild();
 		else
 			currentAST.child = signalDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	signalDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	signalDecl_AST = RefLineAST(currentAST.root);
 	returnAST = signalDecl_AST;
 }
 
 void EsterelParser::signalDeclList() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalDeclList_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalDeclList_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	signalDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -1188,7 +1188,7 @@ void EsterelParser::signalDeclList() {
 			match(COMMA);
 			signalDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1201,67 +1201,67 @@ void EsterelParser::signalDeclList() {
 	if ( inputState->guessing==0 ) {
 		signalDeclList_AST = RefLineAST(currentAST.root);
 #line 183 "esterel.g"
-		signalDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(SIGS,"sigs")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(signalDeclList_AST))));
+		signalDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(SIGS,"sigs")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(signalDeclList_AST))));
 #line 1206 "EsterelParser.cpp"
 		currentAST.root = signalDeclList_AST;
-		if ( signalDeclList_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			signalDeclList_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( signalDeclList_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			signalDeclList_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = signalDeclList_AST->getFirstChild();
 		else
 			currentAST.child = signalDeclList_AST;
 		currentAST.advanceChildToEnd();
 	}
-	signalDeclList_AST = static_cast<RefLineAST>(currentAST.root);
+	signalDeclList_AST = RefLineAST(currentAST.root);
 	returnAST = signalDeclList_AST;
 }
 
 void EsterelParser::signalIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp62_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp62_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp62_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp62_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp62_AST));
 	}
 	match(ID);
-	signalIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	signalIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = signalIdentifier_AST;
 }
 
 void EsterelParser::signalInitializer() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalInitializer_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalInitializer_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp63_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp63_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp63_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp63_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp63_AST));
 	}
 	match(COLEQUALS);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	signalInitializer_AST = static_cast<RefLineAST>(currentAST.root);
+	signalInitializer_AST = RefLineAST(currentAST.root);
 	returnAST = signalInitializer_AST;
 }
 
 void EsterelParser::channelType() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST channelType_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST channelType_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
 	{
 		typeIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		channelType_AST = static_cast<RefLineAST>(currentAST.root);
+		channelType_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_combine:
@@ -1269,7 +1269,7 @@ void EsterelParser::channelType() {
 		match(LITERAL_combine);
 		typeIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_with);
 		{
@@ -1278,7 +1278,7 @@ void EsterelParser::channelType() {
 		{
 			functionIdentifier();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -1289,7 +1289,7 @@ void EsterelParser::channelType() {
 		{
 			predefinedCombineFunction();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -1299,7 +1299,7 @@ void EsterelParser::channelType() {
 		}
 		}
 		}
-		channelType_AST = static_cast<RefLineAST>(currentAST.root);
+		channelType_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -1316,66 +1316,66 @@ void EsterelParser::channelType() {
  *
  ***********************************************************************/
 void EsterelParser::expression() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST expression_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST expression_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	orexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	expression_AST = static_cast<RefLineAST>(currentAST.root);
+	expression_AST = RefLineAST(currentAST.root);
 	returnAST = expression_AST;
 }
 
 void EsterelParser::predefinedCombineFunction() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST predefinedCombineFunction_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST predefinedCombineFunction_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case PLUS:
 	{
-		RefLineAST tmp66_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp66_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp66_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp66_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp66_AST));
 		}
 		match(PLUS);
-		predefinedCombineFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedCombineFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case STAR:
 	{
-		RefLineAST tmp67_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp67_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp67_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp67_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp67_AST));
 		}
 		match(STAR);
-		predefinedCombineFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedCombineFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_or:
 	{
-		RefLineAST tmp68_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp68_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp68_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp68_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp68_AST));
 		}
 		match(LITERAL_or);
-		predefinedCombineFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedCombineFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_and:
 	{
-		RefLineAST tmp69_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp69_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp69_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp69_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp69_AST));
 		}
 		match(LITERAL_and);
-		predefinedCombineFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedCombineFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -1387,13 +1387,13 @@ void EsterelParser::predefinedCombineFunction() {
 }
 
 void EsterelParser::sensorDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sensorDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sensorDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	sensorIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -1402,7 +1402,7 @@ void EsterelParser::sensorDecl() {
 		match(COLON);
 		typeIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -1411,7 +1411,7 @@ void EsterelParser::sensorDecl() {
 		match(LPAREN);
 		typeIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
 		break;
@@ -1425,53 +1425,53 @@ void EsterelParser::sensorDecl() {
 	if ( inputState->guessing==0 ) {
 		sensorDecl_AST = RefLineAST(currentAST.root);
 #line 223 "esterel.g"
-		sensorDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(SDECL,"sdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(sensorDecl_AST))));
+		sensorDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(SDECL,"sdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(sensorDecl_AST))));
 #line 1430 "EsterelParser.cpp"
 		currentAST.root = sensorDecl_AST;
-		if ( sensorDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			sensorDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( sensorDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			sensorDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = sensorDecl_AST->getFirstChild();
 		else
 			currentAST.child = sensorDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	sensorDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	sensorDecl_AST = RefLineAST(currentAST.root);
 	returnAST = sensorDecl_AST;
 }
 
 void EsterelParser::sensorIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sensorIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sensorIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp73_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp73_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp73_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp73_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp73_AST));
 	}
 	match(ID);
-	sensorIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	sensorIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = sensorIdentifier_AST;
 }
 
 void EsterelParser::relationDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST relationDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST relationDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	if ((LA(1) == ID) && (LA(2) == IMPLIES)) {
 		implicationDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		relationDecl_AST = static_cast<RefLineAST>(currentAST.root);
+		relationDecl_AST = RefLineAST(currentAST.root);
 	}
 	else if ((LA(1) == ID) && (LA(2) == POUND)) {
 		exclusionDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		relationDecl_AST = static_cast<RefLineAST>(currentAST.root);
+		relationDecl_AST = RefLineAST(currentAST.root);
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -1481,46 +1481,46 @@ void EsterelParser::relationDecl() {
 }
 
 void EsterelParser::implicationDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST implicationDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST implicationDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	RefLineAST tmp74_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp74_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp74_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp74_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp74_AST));
 	}
 	match(IMPLIES);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	implicationDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	implicationDecl_AST = RefLineAST(currentAST.root);
 	returnAST = implicationDecl_AST;
 }
 
 void EsterelParser::exclusionDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST exclusionDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST exclusionDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	RefLineAST tmp75_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp75_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp75_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp75_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp75_AST));
 	}
 	match(POUND);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -1528,7 +1528,7 @@ void EsterelParser::exclusionDecl() {
 			match(POUND);
 			signalIdentifier();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1538,31 +1538,31 @@ void EsterelParser::exclusionDecl() {
 	}
 	_loop70:;
 	} // ( ... )*
-	exclusionDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	exclusionDecl_AST = RefLineAST(currentAST.root);
 	returnAST = exclusionDecl_AST;
 }
 
 void EsterelParser::orexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST orexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST orexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	andexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_or)) {
-			RefLineAST tmp77_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp77_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp77_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp77_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp77_AST));
 			}
 			match(LITERAL_or);
 			andexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1572,31 +1572,31 @@ void EsterelParser::orexpr() {
 	}
 	_loop74:;
 	} // ( ... )*
-	orexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	orexpr_AST = RefLineAST(currentAST.root);
 	returnAST = orexpr_AST;
 }
 
 void EsterelParser::andexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST andexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST andexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	notexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_and)) {
-			RefLineAST tmp78_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp78_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp78_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp78_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp78_AST));
 			}
 			match(LITERAL_and);
 			notexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1606,29 +1606,29 @@ void EsterelParser::andexpr() {
 	}
 	_loop77:;
 	} // ( ... )*
-	andexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	andexpr_AST = RefLineAST(currentAST.root);
 	returnAST = andexpr_AST;
 }
 
 void EsterelParser::notexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST notexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST notexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_not:
 	{
-		RefLineAST tmp79_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp79_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp79_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp79_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp79_AST));
 		}
 		match(LITERAL_not);
 		cmpexpr();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		notexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		notexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case Integer:
@@ -1646,9 +1646,9 @@ void EsterelParser::notexpr() {
 	{
 		cmpexpr();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		notexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		notexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -1660,13 +1660,13 @@ void EsterelParser::notexpr() {
 }
 
 void EsterelParser::cmpexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST cmpexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST cmpexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	addexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -1675,60 +1675,60 @@ void EsterelParser::cmpexpr() {
 			switch ( LA(1)) {
 			case EQUALS:
 			{
-				RefLineAST tmp80_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp80_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp80_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp80_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp80_AST));
 				}
 				match(EQUALS);
 				break;
 			}
 			case NEQUAL:
 			{
-				RefLineAST tmp81_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp81_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp81_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp81_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp81_AST));
 				}
 				match(NEQUAL);
 				break;
 			}
 			case LESSTHAN:
 			{
-				RefLineAST tmp82_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp82_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp82_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp82_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp82_AST));
 				}
 				match(LESSTHAN);
 				break;
 			}
 			case GREATERTHAN:
 			{
-				RefLineAST tmp83_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp83_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp83_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp83_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp83_AST));
 				}
 				match(GREATERTHAN);
 				break;
 			}
 			case LEQUAL:
 			{
-				RefLineAST tmp84_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp84_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp84_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp84_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp84_AST));
 				}
 				match(LEQUAL);
 				break;
 			}
 			case GEQUAL:
 			{
-				RefLineAST tmp85_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp85_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp85_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp85_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp85_AST));
 				}
 				match(GEQUAL);
 				break;
@@ -1741,7 +1741,7 @@ void EsterelParser::cmpexpr() {
 			}
 			addexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1751,18 +1751,18 @@ void EsterelParser::cmpexpr() {
 	}
 	_loop82:;
 	} // ( ... )*
-	cmpexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	cmpexpr_AST = RefLineAST(currentAST.root);
 	returnAST = cmpexpr_AST;
 }
 
 void EsterelParser::addexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST addexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST addexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	mulexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -1771,20 +1771,20 @@ void EsterelParser::addexpr() {
 			switch ( LA(1)) {
 			case PLUS:
 			{
-				RefLineAST tmp86_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp86_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp86_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp86_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp86_AST));
 				}
 				match(PLUS);
 				break;
 			}
 			case DASH:
 			{
-				RefLineAST tmp87_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp87_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp87_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp87_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp87_AST));
 				}
 				match(DASH);
 				break;
@@ -1797,7 +1797,7 @@ void EsterelParser::addexpr() {
 			}
 			mulexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1807,18 +1807,18 @@ void EsterelParser::addexpr() {
 	}
 	_loop86:;
 	} // ( ... )*
-	addexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	addexpr_AST = RefLineAST(currentAST.root);
 	returnAST = addexpr_AST;
 }
 
 void EsterelParser::mulexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST mulexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST mulexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	unaryexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -1827,30 +1827,30 @@ void EsterelParser::mulexpr() {
 			switch ( LA(1)) {
 			case STAR:
 			{
-				RefLineAST tmp88_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp88_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp88_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp88_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp88_AST));
 				}
 				match(STAR);
 				break;
 			}
 			case SLASH:
 			{
-				RefLineAST tmp89_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp89_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp89_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp89_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp89_AST));
 				}
 				match(SLASH);
 				break;
 			}
 			case LITERAL_mod:
 			{
-				RefLineAST tmp90_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp90_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp90_AST = astFactory->create(LT(1));
-					astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp90_AST));
+					astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp90_AST));
 				}
 				match(LITERAL_mod);
 				break;
@@ -1863,7 +1863,7 @@ void EsterelParser::mulexpr() {
 			}
 			unaryexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -1873,29 +1873,29 @@ void EsterelParser::mulexpr() {
 	}
 	_loop90:;
 	} // ( ... )*
-	mulexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	mulexpr_AST = RefLineAST(currentAST.root);
 	returnAST = mulexpr_AST;
 }
 
 void EsterelParser::unaryexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST unaryexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST unaryexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case DASH:
 	{
-		RefLineAST tmp91_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp91_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp91_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp91_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp91_AST));
 		}
 		match(DASH);
 		unaryexpr();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		unaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LPAREN:
@@ -1903,74 +1903,74 @@ void EsterelParser::unaryexpr() {
 		match(LPAREN);
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
-		unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		unaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case QUESTION:
 	{
-		RefLineAST tmp94_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp94_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp94_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp94_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp94_AST));
 		}
 		match(QUESTION);
 		signalIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		unaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_pre:
 	{
-		RefLineAST tmp95_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp95_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp95_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp95_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp95_AST));
 		}
 		match(LITERAL_pre);
 		match(LPAREN);
 		match(QUESTION);
 		signalIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
-		unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		unaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case DQUESTION:
 	{
-		RefLineAST tmp99_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp99_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp99_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp99_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp99_AST));
 		}
 		match(DQUESTION);
 		trapIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		unaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
 		if ((LA(1) == ID) && (LA(2) == LPAREN)) {
 			functionCall();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
-			unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+			unaryexpr_AST = RefLineAST(currentAST.root);
 		}
 		else if ((_tokenSet_2.member(LA(1))) && (_tokenSet_3.member(LA(2)))) {
 			constant();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
-			unaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+			unaryexpr_AST = RefLineAST(currentAST.root);
 		}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -1980,28 +1980,28 @@ void EsterelParser::unaryexpr() {
 }
 
 void EsterelParser::trapIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp100_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp100_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp100_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp100_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp100_AST));
 	}
 	match(ID);
-	trapIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	trapIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = trapIdentifier_AST;
 }
 
 void EsterelParser::functionCall() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST functionCall_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionCall_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	functionIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LPAREN);
 	{
@@ -2022,7 +2022,7 @@ void EsterelParser::functionCall() {
 	{
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -2030,7 +2030,7 @@ void EsterelParser::functionCall() {
 				match(COMMA);
 				expression();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -2056,24 +2056,24 @@ void EsterelParser::functionCall() {
 	if ( inputState->guessing==0 ) {
 		functionCall_AST = RefLineAST(currentAST.root);
 #line 322 "esterel.g"
-		functionCall_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CALL,"call")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(functionCall_AST))));
+		functionCall_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CALL,"call")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(functionCall_AST))));
 #line 2061 "EsterelParser.cpp"
 		currentAST.root = functionCall_AST;
-		if ( functionCall_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			functionCall_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( functionCall_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			functionCall_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = functionCall_AST->getFirstChild();
 		else
 			currentAST.child = functionCall_AST;
 		currentAST.advanceChildToEnd();
 	}
-	functionCall_AST = static_cast<RefLineAST>(currentAST.root);
+	functionCall_AST = RefLineAST(currentAST.root);
 	returnAST = functionCall_AST;
 }
 
 void EsterelParser::constant() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constant_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constant_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
@@ -2083,9 +2083,9 @@ void EsterelParser::constant() {
 	{
 		constantLiteral();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constant_AST = static_cast<RefLineAST>(currentAST.root);
+		constant_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case Integer:
@@ -2094,9 +2094,9 @@ void EsterelParser::constant() {
 	{
 		unsignedNumber();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constant_AST = static_cast<RefLineAST>(currentAST.root);
+		constant_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2108,49 +2108,49 @@ void EsterelParser::constant() {
 }
 
 void EsterelParser::constantLiteral() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantLiteral_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantLiteral_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
 	{
 		constantIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constantLiteral_AST = static_cast<RefLineAST>(currentAST.root);
+		constantLiteral_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_true:
 	{
-		RefLineAST tmp104_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp104_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp104_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp104_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp104_AST));
 		}
 		match(LITERAL_true);
-		constantLiteral_AST = static_cast<RefLineAST>(currentAST.root);
+		constantLiteral_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_false:
 	{
-		RefLineAST tmp105_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp105_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp105_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp105_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp105_AST));
 		}
 		match(LITERAL_false);
-		constantLiteral_AST = static_cast<RefLineAST>(currentAST.root);
+		constantLiteral_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case StringConstant:
 	{
 		stringConstant();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		constantLiteral_AST = static_cast<RefLineAST>(currentAST.root);
+		constantLiteral_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2162,42 +2162,42 @@ void EsterelParser::constantLiteral() {
 }
 
 void EsterelParser::unsignedNumber() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST unsignedNumber_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST unsignedNumber_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case Integer:
 	{
-		RefLineAST tmp106_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp106_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp106_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp106_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp106_AST));
 		}
 		match(Integer);
-		unsignedNumber_AST = static_cast<RefLineAST>(currentAST.root);
+		unsignedNumber_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case FloatConst:
 	{
-		RefLineAST tmp107_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp107_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp107_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp107_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp107_AST));
 		}
 		match(FloatConst);
-		unsignedNumber_AST = static_cast<RefLineAST>(currentAST.root);
+		unsignedNumber_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case DoubleConst:
 	{
-		RefLineAST tmp108_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp108_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp108_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp108_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp108_AST));
 		}
 		match(DoubleConst);
-		unsignedNumber_AST = static_cast<RefLineAST>(currentAST.root);
+		unsignedNumber_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2209,24 +2209,24 @@ void EsterelParser::unsignedNumber() {
 }
 
 void EsterelParser::stringConstant() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST stringConstant_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST stringConstant_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp109_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp109_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp109_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp109_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp109_AST));
 	}
 	match(StringConstant);
-	stringConstant_AST = static_cast<RefLineAST>(currentAST.root);
+	stringConstant_AST = RefLineAST(currentAST.root);
 	returnAST = stringConstant_AST;
 }
 
 void EsterelParser::signedNumber() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signedNumber_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signedNumber_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case Integer:
@@ -2235,24 +2235,24 @@ void EsterelParser::signedNumber() {
 	{
 		unsignedNumber();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		signedNumber_AST = static_cast<RefLineAST>(currentAST.root);
+		signedNumber_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case DASH:
 	{
-		RefLineAST tmp110_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp110_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp110_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp110_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp110_AST));
 		}
 		match(DASH);
 		unsignedNumber();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		signedNumber_AST = static_cast<RefLineAST>(currentAST.root);
+		signedNumber_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2264,26 +2264,26 @@ void EsterelParser::signedNumber() {
 }
 
 void EsterelParser::signalExpression() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalExpression_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalExpression_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	sandexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_or)) {
-			RefLineAST tmp111_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp111_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp111_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp111_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp111_AST));
 			}
 			match(LITERAL_or);
 			sandexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -2293,31 +2293,31 @@ void EsterelParser::signalExpression() {
 	}
 	_loop103:;
 	} // ( ... )*
-	signalExpression_AST = static_cast<RefLineAST>(currentAST.root);
+	signalExpression_AST = RefLineAST(currentAST.root);
 	returnAST = signalExpression_AST;
 }
 
 void EsterelParser::sandexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sandexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sandexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	sunaryexpr();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_and)) {
-			RefLineAST tmp112_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp112_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp112_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp112_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp112_AST));
 			}
 			match(LITERAL_and);
 			sunaryexpr();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -2327,55 +2327,55 @@ void EsterelParser::sandexpr() {
 	}
 	_loop106:;
 	} // ( ... )*
-	sandexpr_AST = static_cast<RefLineAST>(currentAST.root);
+	sandexpr_AST = RefLineAST(currentAST.root);
 	returnAST = sandexpr_AST;
 }
 
 void EsterelParser::sunaryexpr() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sunaryexpr_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sunaryexpr_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
 	{
 		signalIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		sunaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		sunaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_pre:
 	{
-		RefLineAST tmp113_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp113_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp113_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp113_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp113_AST));
 		}
 		match(LITERAL_pre);
 		match(LPAREN);
 		signalIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
-		sunaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		sunaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_not:
 	{
-		RefLineAST tmp116_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp116_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp116_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp116_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp116_AST));
 		}
 		match(LITERAL_not);
 		sunaryexpr();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		sunaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		sunaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LPAREN:
@@ -2383,10 +2383,10 @@ void EsterelParser::sunaryexpr() {
 		match(LPAREN);
 		signalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
-		sunaryexpr_AST = static_cast<RefLineAST>(currentAST.root);
+		sunaryexpr_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2398,9 +2398,9 @@ void EsterelParser::sunaryexpr() {
 }
 
 void EsterelParser::delayExpression() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST delayExpression_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST delayExpression_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	bool synPredMatched111 = false;
@@ -2423,25 +2423,25 @@ void EsterelParser::delayExpression() {
 	if ( synPredMatched111 ) {
 		delayPair();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 	}
 	else if ((LA(1) == ID || LA(1) == LBRACKET) && (_tokenSet_6.member(LA(2)))) {
 		bracketedSignalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 	}
 	else if ((LA(1) == LITERAL_immediate)) {
-		RefLineAST tmp119_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp119_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp119_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp119_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp119_AST));
 		}
 		match(LITERAL_immediate);
 		bracketedSignalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 	}
 	else {
@@ -2449,23 +2449,23 @@ void EsterelParser::delayExpression() {
 	}
 	
 	}
-	delayExpression_AST = static_cast<RefLineAST>(currentAST.root);
+	delayExpression_AST = RefLineAST(currentAST.root);
 	returnAST = delayExpression_AST;
 }
 
 void EsterelParser::bracketedSignalExpression() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST bracketedSignalExpression_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST bracketedSignalExpression_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
 	{
 		signalIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		bracketedSignalExpression_AST = static_cast<RefLineAST>(currentAST.root);
+		bracketedSignalExpression_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LBRACKET:
@@ -2473,10 +2473,10 @@ void EsterelParser::bracketedSignalExpression() {
 		match(LBRACKET);
 		signalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RBRACKET);
-		bracketedSignalExpression_AST = static_cast<RefLineAST>(currentAST.root);
+		bracketedSignalExpression_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2488,43 +2488,43 @@ void EsterelParser::bracketedSignalExpression() {
 }
 
 void EsterelParser::delayPair() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST delayPair_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST delayPair_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	bracketedSignalExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		delayPair_AST = RefLineAST(currentAST.root);
 #line 353 "esterel.g"
-		delayPair_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(DELAY,"delay")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(delayPair_AST))));
+		delayPair_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(DELAY,"delay")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(delayPair_AST))));
 #line 2508 "EsterelParser.cpp"
 		currentAST.root = delayPair_AST;
-		if ( delayPair_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			delayPair_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( delayPair_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			delayPair_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = delayPair_AST->getFirstChild();
 		else
 			currentAST.child = delayPair_AST;
 		currentAST.advanceChildToEnd();
 	}
-	delayPair_AST = static_cast<RefLineAST>(currentAST.root);
+	delayPair_AST = RefLineAST(currentAST.root);
 	returnAST = delayPair_AST;
 }
 
 void EsterelParser::sequence() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sequence_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sequence_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	atomicStatement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -2532,7 +2532,7 @@ void EsterelParser::sequence() {
 			match(SEMICOLON);
 			atomicStatement();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -2574,122 +2574,122 @@ void EsterelParser::sequence() {
 		sequence_AST = RefLineAST(currentAST.root);
 #line 377 "esterel.g"
 		if (sequence_AST && sequence_AST->getNextSibling()) {
-		sequence_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(SEQUENCE,";")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(sequence_AST))));
+		sequence_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(SEQUENCE,";")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(sequence_AST))));
 		}
 		
 #line 2581 "EsterelParser.cpp"
 		currentAST.root = sequence_AST;
-		if ( sequence_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			sequence_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( sequence_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			sequence_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = sequence_AST->getFirstChild();
 		else
 			currentAST.child = sequence_AST;
 		currentAST.advanceChildToEnd();
 	}
-	sequence_AST = static_cast<RefLineAST>(currentAST.root);
+	sequence_AST = RefLineAST(currentAST.root);
 	returnAST = sequence_AST;
 }
 
 void EsterelParser::atomicStatement() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST atomicStatement_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST atomicStatement_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_nothing:
 	{
-		RefLineAST tmp124_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp124_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp124_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp124_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp124_AST));
 		}
 		match(LITERAL_nothing);
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_pause:
 	{
-		RefLineAST tmp125_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp125_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp125_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp125_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp125_AST));
 		}
 		match(LITERAL_pause);
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_halt:
 	{
-		RefLineAST tmp126_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp126_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp126_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp126_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp126_AST));
 		}
 		match(LITERAL_halt);
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_emit:
 	{
 		emit();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_sustain:
 	{
 		sustain();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case ID:
 	{
 		assignment();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_call:
 	{
 		procedureCall();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_present:
 	{
 		present();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_if:
 	{
 		ifstatement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_loop:
 	{
 		loop();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_positive:
@@ -2697,9 +2697,9 @@ void EsterelParser::atomicStatement() {
 	{
 		repeat();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_abort:
@@ -2707,81 +2707,81 @@ void EsterelParser::atomicStatement() {
 	{
 		abort();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_await:
 	{
 		await();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_every:
 	{
 		every();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_suspend:
 	{
 		suspend();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_trap:
 	{
 		trap();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_exit:
 	{
 		exit();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_exec:
 	{
 		exec();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_var:
 	{
 		localvariableDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_signal:
 	{
 		localSignalDecl();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_run:
@@ -2789,9 +2789,9 @@ void EsterelParser::atomicStatement() {
 	{
 		runModule();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LBRACKET:
@@ -2799,19 +2799,19 @@ void EsterelParser::atomicStatement() {
 		match(LBRACKET);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RBRACKET);
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_do:
 	{
 		doStatements();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		atomicStatement_AST = static_cast<RefLineAST>(currentAST.root);
+		atomicStatement_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -2823,19 +2823,19 @@ void EsterelParser::atomicStatement() {
 }
 
 void EsterelParser::emit() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST emit_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST emit_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp129_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp129_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp129_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp129_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp129_AST));
 	}
 	match(LITERAL_emit);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -2844,7 +2844,7 @@ void EsterelParser::emit() {
 		match(LPAREN);
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
 		break;
@@ -2871,24 +2871,24 @@ void EsterelParser::emit() {
 	}
 	}
 	}
-	emit_AST = static_cast<RefLineAST>(currentAST.root);
+	emit_AST = RefLineAST(currentAST.root);
 	returnAST = emit_AST;
 }
 
 void EsterelParser::sustain() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST sustain_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sustain_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp132_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp132_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp132_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp132_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp132_AST));
 	}
 	match(LITERAL_sustain);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -2897,7 +2897,7 @@ void EsterelParser::sustain() {
 		match(LPAREN);
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
 		break;
@@ -2924,69 +2924,69 @@ void EsterelParser::sustain() {
 	}
 	}
 	}
-	sustain_AST = static_cast<RefLineAST>(currentAST.root);
+	sustain_AST = RefLineAST(currentAST.root);
 	returnAST = sustain_AST;
 }
 
 void EsterelParser::assignment() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST assignment_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST assignment_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	variableIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	RefLineAST tmp135_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp135_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp135_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp135_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp135_AST));
 	}
 	match(COLEQUALS);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	assignment_AST = static_cast<RefLineAST>(currentAST.root);
+	assignment_AST = RefLineAST(currentAST.root);
 	returnAST = assignment_AST;
 }
 
 void EsterelParser::procedureCall() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST procedureCall_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureCall_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp136_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp136_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp136_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp136_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp136_AST));
 	}
 	match(LITERAL_call);
 	procedureIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	refArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	valueArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	procedureCall_AST = static_cast<RefLineAST>(currentAST.root);
+	procedureCall_AST = RefLineAST(currentAST.root);
 	returnAST = procedureCall_AST;
 }
 
 void EsterelParser::present() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST present_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST present_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp137_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp137_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp137_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp137_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp137_AST));
 	}
 	match(LITERAL_present);
 	{
@@ -2999,7 +2999,7 @@ void EsterelParser::present() {
 	{
 		presentThenPart();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3011,7 +3011,7 @@ void EsterelParser::present() {
 			if ((LA(1) == LITERAL_case)) {
 				presentCase();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -3036,7 +3036,7 @@ void EsterelParser::present() {
 	{
 		elsePart();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3080,24 +3080,24 @@ void EsterelParser::present() {
 	}
 	}
 	}
-	present_AST = static_cast<RefLineAST>(currentAST.root);
+	present_AST = RefLineAST(currentAST.root);
 	returnAST = present_AST;
 }
 
 void EsterelParser::ifstatement() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST ifstatement_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST ifstatement_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp140_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp140_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp140_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp140_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp140_AST));
 	}
 	match(LITERAL_if);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -3105,7 +3105,7 @@ void EsterelParser::ifstatement() {
 	{
 		thenPart();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3126,7 +3126,7 @@ void EsterelParser::ifstatement() {
 		if ((LA(1) == LITERAL_elsif)) {
 			elsif();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -3142,7 +3142,7 @@ void EsterelParser::ifstatement() {
 	{
 		elsePart();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3186,24 +3186,24 @@ void EsterelParser::ifstatement() {
 	}
 	}
 	}
-	ifstatement_AST = static_cast<RefLineAST>(currentAST.root);
+	ifstatement_AST = RefLineAST(currentAST.root);
 	returnAST = ifstatement_AST;
 }
 
 void EsterelParser::loop() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST loop_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST loop_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp143_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp143_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp143_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp143_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp143_AST));
 	}
 	match(LITERAL_loop);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -3246,7 +3246,7 @@ void EsterelParser::loop() {
 		match(LITERAL_each);
 		delayExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3256,23 +3256,23 @@ void EsterelParser::loop() {
 	}
 	}
 	}
-	loop_AST = static_cast<RefLineAST>(currentAST.root);
+	loop_AST = RefLineAST(currentAST.root);
 	returnAST = loop_AST;
 }
 
 void EsterelParser::repeat() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST repeat_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST repeat_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	switch ( LA(1)) {
 	case LITERAL_positive:
 	{
-		RefLineAST tmp147_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp147_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp147_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp147_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp147_AST));
 		}
 		match(LITERAL_positive);
 		break;
@@ -3287,20 +3287,20 @@ void EsterelParser::repeat() {
 	}
 	}
 	}
-	RefLineAST tmp148_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp148_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp148_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp148_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp148_AST));
 	}
 	match(LITERAL_repeat);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_times);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_end);
 	{
@@ -3332,27 +3332,27 @@ void EsterelParser::repeat() {
 	}
 	}
 	}
-	repeat_AST = static_cast<RefLineAST>(currentAST.root);
+	repeat_AST = RefLineAST(currentAST.root);
 	returnAST = repeat_AST;
 }
 
 void EsterelParser::abort() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST abort_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST abort_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_abort:
 	{
-		RefLineAST tmp152_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp152_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp152_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp152_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp152_AST));
 		}
 		match(LITERAL_abort);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_when);
 		{
@@ -3375,7 +3375,7 @@ void EsterelParser::abort() {
 		{
 			abortOneCaseStrong();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -3387,7 +3387,7 @@ void EsterelParser::abort() {
 				if ((LA(1) == LITERAL_case)) {
 					acase();
 					if (inputState->guessing==0) {
-						astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+						astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 					}
 				}
 				else {
@@ -3398,20 +3398,20 @@ void EsterelParser::abort() {
 			}
 			_loop163:;
 			}  // ( ... )+
-			RefLineAST tmp154_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp154_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp154_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp154_AST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp154_AST));
 			}
 			match(LITERAL_end);
 			{
 			switch ( LA(1)) {
 			case LITERAL_abort:
 			{
-				RefLineAST tmp155_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp155_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp155_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp155_AST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp155_AST));
 				}
 				match(LITERAL_abort);
 				break;
@@ -3446,26 +3446,26 @@ void EsterelParser::abort() {
 		}
 		}
 		}
-		abort_AST = static_cast<RefLineAST>(currentAST.root);
+		abort_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_weak:
 	{
-		RefLineAST tmp156_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp156_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp156_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp156_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp156_AST));
 		}
 		match(LITERAL_weak);
-		RefLineAST tmp157_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp157_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp157_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp157_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp157_AST));
 		}
 		match(LITERAL_abort);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_when);
 		{
@@ -3488,7 +3488,7 @@ void EsterelParser::abort() {
 		{
 			abortOneCaseWeak();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -3500,7 +3500,7 @@ void EsterelParser::abort() {
 				if ((LA(1) == LITERAL_case)) {
 					acase();
 					if (inputState->guessing==0) {
-						astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+						astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 					}
 				}
 				else {
@@ -3511,10 +3511,10 @@ void EsterelParser::abort() {
 			}
 			_loop167:;
 			}  // ( ... )+
-			RefLineAST tmp159_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp159_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp159_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp159_AST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp159_AST));
 			}
 			match(LITERAL_end);
 			{
@@ -3526,10 +3526,10 @@ void EsterelParser::abort() {
 				switch ( LA(1)) {
 				case LITERAL_weak:
 				{
-					RefLineAST tmp160_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+					RefLineAST tmp160_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 					if ( inputState->guessing == 0 ) {
 						tmp160_AST = astFactory->create(LT(1));
-						astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp160_AST));
+						astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp160_AST));
 					}
 					match(LITERAL_weak);
 					break;
@@ -3544,10 +3544,10 @@ void EsterelParser::abort() {
 				}
 				}
 				}
-				RefLineAST tmp161_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+				RefLineAST tmp161_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 				if ( inputState->guessing == 0 ) {
 					tmp161_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp161_AST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp161_AST));
 				}
 				match(LITERAL_abort);
 				break;
@@ -3582,7 +3582,7 @@ void EsterelParser::abort() {
 		}
 		}
 		}
-		abort_AST = static_cast<RefLineAST>(currentAST.root);
+		abort_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -3594,14 +3594,14 @@ void EsterelParser::abort() {
 }
 
 void EsterelParser::await() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST await_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST await_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp162_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp162_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp162_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp162_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp162_AST));
 	}
 	match(LITERAL_await);
 	{
@@ -3624,7 +3624,7 @@ void EsterelParser::await() {
 	{
 		awaitOneCase();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -3636,7 +3636,7 @@ void EsterelParser::await() {
 			if ((LA(1) == LITERAL_case)) {
 				acase();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -3685,29 +3685,29 @@ void EsterelParser::await() {
 	}
 	}
 	}
-	await_AST = static_cast<RefLineAST>(currentAST.root);
+	await_AST = RefLineAST(currentAST.root);
 	returnAST = await_AST;
 }
 
 void EsterelParser::every() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST every_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST every_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp165_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp165_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp165_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp165_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp165_AST));
 	}
 	match(LITERAL_every);
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_do);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_end);
 	{
@@ -3739,60 +3739,60 @@ void EsterelParser::every() {
 	}
 	}
 	}
-	every_AST = static_cast<RefLineAST>(currentAST.root);
+	every_AST = RefLineAST(currentAST.root);
 	returnAST = every_AST;
 }
 
 void EsterelParser::suspend() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST suspend_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST suspend_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp169_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp169_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp169_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp169_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp169_AST));
 	}
 	match(LITERAL_suspend);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_when);
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	suspend_AST = static_cast<RefLineAST>(currentAST.root);
+	suspend_AST = RefLineAST(currentAST.root);
 	returnAST = suspend_AST;
 }
 
 void EsterelParser::trap() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trap_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trap_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp171_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp171_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp171_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp171_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp171_AST));
 	}
 	match(LITERAL_trap);
 	trapDeclList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_in);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_handle)) {
 			trapHandler();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -3832,24 +3832,24 @@ void EsterelParser::trap() {
 	}
 	}
 	}
-	trap_AST = static_cast<RefLineAST>(currentAST.root);
+	trap_AST = RefLineAST(currentAST.root);
 	returnAST = trap_AST;
 }
 
 void EsterelParser::exit() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST exit_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST exit_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp175_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp175_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp175_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp175_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp175_AST));
 	}
 	match(LITERAL_exit);
 	trapIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -3858,7 +3858,7 @@ void EsterelParser::exit() {
 		match(LPAREN);
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
 		break;
@@ -3885,33 +3885,33 @@ void EsterelParser::exit() {
 	}
 	}
 	}
-	exit_AST = static_cast<RefLineAST>(currentAST.root);
+	exit_AST = RefLineAST(currentAST.root);
 	returnAST = exit_AST;
 }
 
 void EsterelParser::exec() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST exec_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST exec_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	if ((LA(1) == LITERAL_exec) && (LA(2) == ID)) {
-		RefLineAST tmp178_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp178_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp178_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp178_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp178_AST));
 		}
 		match(LITERAL_exec);
 		execOneCase();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		exec_AST = static_cast<RefLineAST>(currentAST.root);
+		exec_AST = RefLineAST(currentAST.root);
 	}
 	else if ((LA(1) == LITERAL_exec) && (LA(2) == LITERAL_case)) {
-		RefLineAST tmp179_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp179_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp179_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp179_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp179_AST));
 		}
 		match(LITERAL_exec);
 		{ // ( ... )+
@@ -3920,7 +3920,7 @@ void EsterelParser::exec() {
 			if ((LA(1) == LITERAL_case)) {
 				execCase();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -3961,7 +3961,7 @@ void EsterelParser::exec() {
 		}
 		}
 		}
-		exec_AST = static_cast<RefLineAST>(currentAST.root);
+		exec_AST = RefLineAST(currentAST.root);
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -3971,24 +3971,24 @@ void EsterelParser::exec() {
 }
 
 void EsterelParser::localvariableDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST localvariableDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST localvariableDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp182_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp182_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp182_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp182_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp182_AST));
 	}
 	match(LITERAL_var);
 	variableDeclList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_in);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_end);
 	{
@@ -4020,29 +4020,29 @@ void EsterelParser::localvariableDecl() {
 	}
 	}
 	}
-	localvariableDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	localvariableDecl_AST = RefLineAST(currentAST.root);
 	returnAST = localvariableDecl_AST;
 }
 
 void EsterelParser::localSignalDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST localSignalDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST localSignalDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp186_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp186_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp186_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp186_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp186_AST));
 	}
 	match(LITERAL_signal);
 	signalDeclList();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_in);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_end);
 	{
@@ -4074,14 +4074,14 @@ void EsterelParser::localSignalDecl() {
 	}
 	}
 	}
-	localSignalDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	localSignalDecl_AST = RefLineAST(currentAST.root);
 	returnAST = localSignalDecl_AST;
 }
 
 void EsterelParser::runModule() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST runModule_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST runModule_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	switch ( LA(1)) {
@@ -4103,7 +4103,7 @@ void EsterelParser::runModule() {
 	}
 	moduleIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4112,7 +4112,7 @@ void EsterelParser::runModule() {
 		match(SLASH);
 		moduleIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -4146,7 +4146,7 @@ void EsterelParser::runModule() {
 		match(LBRACKET);
 		renaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -4154,7 +4154,7 @@ void EsterelParser::runModule() {
 				match(SEMICOLON);
 				renaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -4192,29 +4192,29 @@ void EsterelParser::runModule() {
 	if ( inputState->guessing==0 ) {
 		runModule_AST = RefLineAST(currentAST.root);
 #line 664 "esterel.g"
-		runModule_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(RUN,"run")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(runModule_AST))));
+		runModule_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(RUN,"run")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(runModule_AST))));
 #line 4197 "EsterelParser.cpp"
 		currentAST.root = runModule_AST;
-		if ( runModule_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			runModule_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( runModule_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			runModule_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = runModule_AST->getFirstChild();
 		else
 			currentAST.child = runModule_AST;
 		currentAST.advanceChildToEnd();
 	}
-	runModule_AST = static_cast<RefLineAST>(currentAST.root);
+	runModule_AST = RefLineAST(currentAST.root);
 	returnAST = runModule_AST;
 }
 
 void EsterelParser::doStatements() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST doStatements_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST doStatements_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LITERAL_do);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4223,7 +4223,7 @@ void EsterelParser::doStatements() {
 		match(LITERAL_watching);
 		delayExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{
 		switch ( LA(1)) {
@@ -4232,7 +4232,7 @@ void EsterelParser::doStatements() {
 			match(LITERAL_timeout);
 			statement();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			match(LITERAL_end);
 			{
@@ -4291,11 +4291,11 @@ void EsterelParser::doStatements() {
 		if ( inputState->guessing==0 ) {
 			doStatements_AST = RefLineAST(currentAST.root);
 #line 731 "esterel.g"
-			doStatements_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(DOWATCHING,"dowatching")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(doStatements_AST))));
+			doStatements_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(DOWATCHING,"dowatching")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(doStatements_AST))));
 #line 4296 "EsterelParser.cpp"
 			currentAST.root = doStatements_AST;
-			if ( doStatements_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-				doStatements_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if ( doStatements_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+				doStatements_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				  currentAST.child = doStatements_AST->getFirstChild();
 			else
 				currentAST.child = doStatements_AST;
@@ -4308,16 +4308,16 @@ void EsterelParser::doStatements() {
 		match(LITERAL_upto);
 		delayExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		if ( inputState->guessing==0 ) {
 			doStatements_AST = RefLineAST(currentAST.root);
 #line 733 "esterel.g"
-			doStatements_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(DOUPTO,"doupto")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(doStatements_AST))));
+			doStatements_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(DOUPTO,"doupto")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(doStatements_AST))));
 #line 4318 "EsterelParser.cpp"
 			currentAST.root = doStatements_AST;
-			if ( doStatements_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-				doStatements_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if ( doStatements_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+				doStatements_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				  currentAST.child = doStatements_AST->getFirstChild();
 			else
 				currentAST.child = doStatements_AST;
@@ -4331,29 +4331,29 @@ void EsterelParser::doStatements() {
 	}
 	}
 	}
-	doStatements_AST = static_cast<RefLineAST>(currentAST.root);
+	doStatements_AST = RefLineAST(currentAST.root);
 	returnAST = doStatements_AST;
 }
 
 void EsterelParser::variableIdentifier() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableIdentifier_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableIdentifier_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp202_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp202_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp202_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp202_AST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp202_AST));
 	}
 	match(ID);
-	variableIdentifier_AST = static_cast<RefLineAST>(currentAST.root);
+	variableIdentifier_AST = RefLineAST(currentAST.root);
 	returnAST = variableIdentifier_AST;
 }
 
 void EsterelParser::refArgs() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST refArgs_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST refArgs_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LPAREN);
 	{
@@ -4362,7 +4362,7 @@ void EsterelParser::refArgs() {
 	{
 		variableIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -4370,7 +4370,7 @@ void EsterelParser::refArgs() {
 				match(COMMA);
 				variableIdentifier();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -4396,24 +4396,24 @@ void EsterelParser::refArgs() {
 	if ( inputState->guessing==0 ) {
 		refArgs_AST = RefLineAST(currentAST.root);
 #line 432 "esterel.g"
-		refArgs_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(VARS,"vars")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(refArgs_AST))));
+		refArgs_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(VARS,"vars")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(refArgs_AST))));
 #line 4401 "EsterelParser.cpp"
 		currentAST.root = refArgs_AST;
-		if ( refArgs_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			refArgs_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( refArgs_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			refArgs_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = refArgs_AST->getFirstChild();
 		else
 			currentAST.child = refArgs_AST;
 		currentAST.advanceChildToEnd();
 	}
-	refArgs_AST = static_cast<RefLineAST>(currentAST.root);
+	refArgs_AST = RefLineAST(currentAST.root);
 	returnAST = refArgs_AST;
 }
 
 void EsterelParser::valueArgs() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST valueArgs_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST valueArgs_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LPAREN);
 	{
@@ -4434,7 +4434,7 @@ void EsterelParser::valueArgs() {
 	{
 		expression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -4442,7 +4442,7 @@ void EsterelParser::valueArgs() {
 				match(COMMA);
 				expression();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -4468,28 +4468,28 @@ void EsterelParser::valueArgs() {
 	if ( inputState->guessing==0 ) {
 		valueArgs_AST = RefLineAST(currentAST.root);
 #line 438 "esterel.g"
-		valueArgs_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(ARGS,"args")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(valueArgs_AST))));
+		valueArgs_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(ARGS,"args")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(valueArgs_AST))));
 #line 4473 "EsterelParser.cpp"
 		currentAST.root = valueArgs_AST;
-		if ( valueArgs_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			valueArgs_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( valueArgs_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			valueArgs_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = valueArgs_AST->getFirstChild();
 		else
 			currentAST.child = valueArgs_AST;
 		currentAST.advanceChildToEnd();
 	}
-	valueArgs_AST = static_cast<RefLineAST>(currentAST.root);
+	valueArgs_AST = RefLineAST(currentAST.root);
 	returnAST = valueArgs_AST;
 }
 
 void EsterelParser::presentThenPart() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST presentThenPart_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST presentThenPart_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	presentEvent();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4498,7 +4498,7 @@ void EsterelParser::presentThenPart() {
 		match(LITERAL_then);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -4516,29 +4516,29 @@ void EsterelParser::presentThenPart() {
 	if ( inputState->guessing==0 ) {
 		presentThenPart_AST = RefLineAST(currentAST.root);
 #line 451 "esterel.g"
-		presentThenPart_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(presentThenPart_AST))));
+		presentThenPart_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(presentThenPart_AST))));
 #line 4521 "EsterelParser.cpp"
 		currentAST.root = presentThenPart_AST;
-		if ( presentThenPart_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			presentThenPart_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( presentThenPart_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			presentThenPart_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = presentThenPart_AST->getFirstChild();
 		else
 			currentAST.child = presentThenPart_AST;
 		currentAST.advanceChildToEnd();
 	}
-	presentThenPart_AST = static_cast<RefLineAST>(currentAST.root);
+	presentThenPart_AST = RefLineAST(currentAST.root);
 	returnAST = presentThenPart_AST;
 }
 
 void EsterelParser::presentCase() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST presentCase_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST presentCase_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LITERAL_case);
 	presentEvent();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4547,7 +4547,7 @@ void EsterelParser::presentCase() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -4566,43 +4566,43 @@ void EsterelParser::presentCase() {
 	if ( inputState->guessing==0 ) {
 		presentCase_AST = RefLineAST(currentAST.root);
 #line 468 "esterel.g"
-		presentCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(presentCase_AST))));
+		presentCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(presentCase_AST))));
 #line 4571 "EsterelParser.cpp"
 		currentAST.root = presentCase_AST;
-		if ( presentCase_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			presentCase_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( presentCase_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			presentCase_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = presentCase_AST->getFirstChild();
 		else
 			currentAST.child = presentCase_AST;
 		currentAST.advanceChildToEnd();
 	}
-	presentCase_AST = static_cast<RefLineAST>(currentAST.root);
+	presentCase_AST = RefLineAST(currentAST.root);
 	returnAST = presentCase_AST;
 }
 
 void EsterelParser::elsePart() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST elsePart_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST elsePart_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp212_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp212_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp212_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp212_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp212_AST));
 	}
 	match(LITERAL_else);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	elsePart_AST = static_cast<RefLineAST>(currentAST.root);
+	elsePart_AST = RefLineAST(currentAST.root);
 	returnAST = elsePart_AST;
 }
 
 void EsterelParser::presentEvent() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST presentEvent_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST presentEvent_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	switch ( LA(1)) {
@@ -4613,7 +4613,7 @@ void EsterelParser::presentEvent() {
 	{
 		signalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -4622,7 +4622,7 @@ void EsterelParser::presentEvent() {
 		match(LBRACKET);
 		signalExpression();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RBRACKET);
 		break;
@@ -4633,61 +4633,61 @@ void EsterelParser::presentEvent() {
 	}
 	}
 	}
-	presentEvent_AST = static_cast<RefLineAST>(currentAST.root);
+	presentEvent_AST = RefLineAST(currentAST.root);
 	returnAST = presentEvent_AST;
 }
 
 void EsterelParser::thenPart() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST thenPart_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST thenPart_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp215_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp215_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp215_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp215_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp215_AST));
 	}
 	match(LITERAL_then);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	thenPart_AST = static_cast<RefLineAST>(currentAST.root);
+	thenPart_AST = RefLineAST(currentAST.root);
 	returnAST = thenPart_AST;
 }
 
 void EsterelParser::elsif() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST elsif_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST elsif_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp216_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp216_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp216_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp216_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp216_AST));
 	}
 	match(LITERAL_elsif);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_then);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	elsif_AST = static_cast<RefLineAST>(currentAST.root);
+	elsif_AST = RefLineAST(currentAST.root);
 	returnAST = elsif_AST;
 }
 
 void EsterelParser::abortOneCaseStrong() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST abortOneCaseStrong_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST abortOneCaseStrong_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4696,7 +4696,7 @@ void EsterelParser::abortOneCaseStrong() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_end);
 		{
@@ -4755,29 +4755,29 @@ void EsterelParser::abortOneCaseStrong() {
 	if ( inputState->guessing==0 ) {
 		abortOneCaseStrong_AST = RefLineAST(currentAST.root);
 #line 506 "esterel.g"
-		abortOneCaseStrong_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(abortOneCaseStrong_AST))));
+		abortOneCaseStrong_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(abortOneCaseStrong_AST))));
 #line 4760 "EsterelParser.cpp"
 		currentAST.root = abortOneCaseStrong_AST;
-		if ( abortOneCaseStrong_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			abortOneCaseStrong_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( abortOneCaseStrong_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			abortOneCaseStrong_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = abortOneCaseStrong_AST->getFirstChild();
 		else
 			currentAST.child = abortOneCaseStrong_AST;
 		currentAST.advanceChildToEnd();
 	}
-	abortOneCaseStrong_AST = static_cast<RefLineAST>(currentAST.root);
+	abortOneCaseStrong_AST = RefLineAST(currentAST.root);
 	returnAST = abortOneCaseStrong_AST;
 }
 
 void EsterelParser::acase() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST acase_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST acase_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LITERAL_case);
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4786,7 +4786,7 @@ void EsterelParser::acase() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -4804,28 +4804,28 @@ void EsterelParser::acase() {
 	if ( inputState->guessing==0 ) {
 		acase_AST = RefLineAST(currentAST.root);
 #line 518 "esterel.g"
-		acase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(acase_AST))));
+		acase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(acase_AST))));
 #line 4809 "EsterelParser.cpp"
 		currentAST.root = acase_AST;
-		if ( acase_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			acase_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( acase_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			acase_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = acase_AST->getFirstChild();
 		else
 			currentAST.child = acase_AST;
 		currentAST.advanceChildToEnd();
 	}
-	acase_AST = static_cast<RefLineAST>(currentAST.root);
+	acase_AST = RefLineAST(currentAST.root);
 	returnAST = acase_AST;
 }
 
 void EsterelParser::abortOneCaseWeak() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST abortOneCaseWeak_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST abortOneCaseWeak_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4834,7 +4834,7 @@ void EsterelParser::abortOneCaseWeak() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_end);
 		{
@@ -4911,28 +4911,28 @@ void EsterelParser::abortOneCaseWeak() {
 	if ( inputState->guessing==0 ) {
 		abortOneCaseWeak_AST = RefLineAST(currentAST.root);
 #line 511 "esterel.g"
-		abortOneCaseWeak_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(abortOneCaseWeak_AST))));
+		abortOneCaseWeak_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(abortOneCaseWeak_AST))));
 #line 4916 "EsterelParser.cpp"
 		currentAST.root = abortOneCaseWeak_AST;
-		if ( abortOneCaseWeak_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			abortOneCaseWeak_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( abortOneCaseWeak_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			abortOneCaseWeak_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = abortOneCaseWeak_AST->getFirstChild();
 		else
 			currentAST.child = abortOneCaseWeak_AST;
 		currentAST.advanceChildToEnd();
 	}
-	abortOneCaseWeak_AST = static_cast<RefLineAST>(currentAST.root);
+	abortOneCaseWeak_AST = RefLineAST(currentAST.root);
 	returnAST = abortOneCaseWeak_AST;
 }
 
 void EsterelParser::awaitOneCase() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST awaitOneCase_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST awaitOneCase_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	delayExpression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -4941,7 +4941,7 @@ void EsterelParser::awaitOneCase() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_end);
 		{
@@ -5000,28 +5000,28 @@ void EsterelParser::awaitOneCase() {
 	if ( inputState->guessing==0 ) {
 		awaitOneCase_AST = RefLineAST(currentAST.root);
 #line 529 "esterel.g"
-		awaitOneCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(awaitOneCase_AST))));
+		awaitOneCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(awaitOneCase_AST))));
 #line 5005 "EsterelParser.cpp"
 		currentAST.root = awaitOneCase_AST;
-		if ( awaitOneCase_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			awaitOneCase_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( awaitOneCase_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			awaitOneCase_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = awaitOneCase_AST->getFirstChild();
 		else
 			currentAST.child = awaitOneCase_AST;
 		currentAST.advanceChildToEnd();
 	}
-	awaitOneCase_AST = static_cast<RefLineAST>(currentAST.root);
+	awaitOneCase_AST = RefLineAST(currentAST.root);
 	returnAST = awaitOneCase_AST;
 }
 
 void EsterelParser::trapDeclList() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapDeclList_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapDeclList_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	trapDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -5029,7 +5029,7 @@ void EsterelParser::trapDeclList() {
 			match(COMMA);
 			trapDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -5042,52 +5042,52 @@ void EsterelParser::trapDeclList() {
 	if ( inputState->guessing==0 ) {
 		trapDeclList_AST = RefLineAST(currentAST.root);
 #line 561 "esterel.g"
-		trapDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TRAPS,"traps")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(trapDeclList_AST))));
+		trapDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TRAPS,"traps")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(trapDeclList_AST))));
 #line 5047 "EsterelParser.cpp"
 		currentAST.root = trapDeclList_AST;
-		if ( trapDeclList_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			trapDeclList_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( trapDeclList_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			trapDeclList_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = trapDeclList_AST->getFirstChild();
 		else
 			currentAST.child = trapDeclList_AST;
 		currentAST.advanceChildToEnd();
 	}
-	trapDeclList_AST = static_cast<RefLineAST>(currentAST.root);
+	trapDeclList_AST = RefLineAST(currentAST.root);
 	returnAST = trapDeclList_AST;
 }
 
 void EsterelParser::trapHandler() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapHandler_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapHandler_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp231_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp231_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp231_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp231_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp231_AST));
 	}
 	match(LITERAL_handle);
 	trapEvent();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_do);
 	statement();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	trapHandler_AST = static_cast<RefLineAST>(currentAST.root);
+	trapHandler_AST = RefLineAST(currentAST.root);
 	returnAST = trapHandler_AST;
 }
 
 void EsterelParser::trapDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	trapIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -5100,7 +5100,7 @@ void EsterelParser::trapDecl() {
 		{
 			trapInitializer();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 			break;
 		}
@@ -5117,7 +5117,7 @@ void EsterelParser::trapDecl() {
 		match(COLON);
 		channelType();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -5135,60 +5135,60 @@ void EsterelParser::trapDecl() {
 	if ( inputState->guessing==0 ) {
 		trapDecl_AST = RefLineAST(currentAST.root);
 #line 566 "esterel.g"
-		trapDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TDECL,"tdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(trapDecl_AST))));
+		trapDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TDECL,"tdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(trapDecl_AST))));
 #line 5140 "EsterelParser.cpp"
 		currentAST.root = trapDecl_AST;
-		if ( trapDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			trapDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( trapDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			trapDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = trapDecl_AST->getFirstChild();
 		else
 			currentAST.child = trapDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	trapDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	trapDecl_AST = RefLineAST(currentAST.root);
 	returnAST = trapDecl_AST;
 }
 
 void EsterelParser::trapInitializer() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapInitializer_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapInitializer_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp234_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp234_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp234_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp234_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp234_AST));
 	}
 	match(COLEQUALS);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	trapInitializer_AST = static_cast<RefLineAST>(currentAST.root);
+	trapInitializer_AST = RefLineAST(currentAST.root);
 	returnAST = trapInitializer_AST;
 }
 
 void EsterelParser::trapEvent() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST trapEvent_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapEvent_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	eand();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_or)) {
-			RefLineAST tmp235_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp235_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp235_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp235_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp235_AST));
 			}
 			match(LITERAL_or);
 			eand();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -5198,31 +5198,31 @@ void EsterelParser::trapEvent() {
 	}
 	_loop209:;
 	} // ( ... )*
-	trapEvent_AST = static_cast<RefLineAST>(currentAST.root);
+	trapEvent_AST = RefLineAST(currentAST.root);
 	returnAST = trapEvent_AST;
 }
 
 void EsterelParser::eand() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST eand_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST eand_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	eunary();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
 		if ((LA(1) == LITERAL_and)) {
-			RefLineAST tmp236_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+			RefLineAST tmp236_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 			if ( inputState->guessing == 0 ) {
 				tmp236_AST = astFactory->create(LT(1));
-				astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp236_AST));
+				astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp236_AST));
 			}
 			match(LITERAL_and);
 			eunary();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -5232,23 +5232,23 @@ void EsterelParser::eand() {
 	}
 	_loop212:;
 	} // ( ... )*
-	eand_AST = static_cast<RefLineAST>(currentAST.root);
+	eand_AST = RefLineAST(currentAST.root);
 	returnAST = eand_AST;
 }
 
 void EsterelParser::eunary() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST eunary_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST eunary_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case ID:
 	{
 		trapIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		eunary_AST = static_cast<RefLineAST>(currentAST.root);
+		eunary_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LPAREN:
@@ -5256,25 +5256,25 @@ void EsterelParser::eunary() {
 		match(LPAREN);
 		trapEvent();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(RPAREN);
-		eunary_AST = static_cast<RefLineAST>(currentAST.root);
+		eunary_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_not:
 	{
-		RefLineAST tmp239_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp239_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp239_AST = astFactory->create(LT(1));
-			astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp239_AST));
+			astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp239_AST));
 		}
 		match(LITERAL_not);
 		eunary();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
-		eunary_AST = static_cast<RefLineAST>(currentAST.root);
+		eunary_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -5286,26 +5286,26 @@ void EsterelParser::eunary() {
 }
 
 void EsterelParser::execOneCase() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST execOneCase_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST execOneCase_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	taskIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	refArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	valueArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_return);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -5314,7 +5314,7 @@ void EsterelParser::execOneCase() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(LITERAL_end);
 		{
@@ -5373,42 +5373,42 @@ void EsterelParser::execOneCase() {
 	if ( inputState->guessing==0 ) {
 		execOneCase_AST = RefLineAST(currentAST.root);
 #line 605 "esterel.g"
-		execOneCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(execOneCase_AST))));
+		execOneCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(execOneCase_AST))));
 #line 5378 "EsterelParser.cpp"
 		currentAST.root = execOneCase_AST;
-		if ( execOneCase_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			execOneCase_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( execOneCase_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			execOneCase_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = execOneCase_AST->getFirstChild();
 		else
 			currentAST.child = execOneCase_AST;
 		currentAST.advanceChildToEnd();
 	}
-	execOneCase_AST = static_cast<RefLineAST>(currentAST.root);
+	execOneCase_AST = RefLineAST(currentAST.root);
 	returnAST = execOneCase_AST;
 }
 
 void EsterelParser::execCase() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST execCase_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST execCase_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	match(LITERAL_case);
 	taskIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	refArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	valueArgs();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(LITERAL_return);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -5417,7 +5417,7 @@ void EsterelParser::execCase() {
 		match(LITERAL_do);
 		statement();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -5435,28 +5435,28 @@ void EsterelParser::execCase() {
 	if ( inputState->guessing==0 ) {
 		execCase_AST = RefLineAST(currentAST.root);
 #line 611 "esterel.g"
-		execCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CASE,"case")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(execCase_AST))));
+		execCase_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CASE,"case")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(execCase_AST))));
 #line 5440 "EsterelParser.cpp"
 		currentAST.root = execCase_AST;
-		if ( execCase_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			execCase_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( execCase_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			execCase_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = execCase_AST->getFirstChild();
 		else
 			currentAST.child = execCase_AST;
 		currentAST.advanceChildToEnd();
 	}
-	execCase_AST = static_cast<RefLineAST>(currentAST.root);
+	execCase_AST = RefLineAST(currentAST.root);
 	returnAST = execCase_AST;
 }
 
 void EsterelParser::variableDeclList() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableDeclList_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableDeclList_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	variableDecls();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -5464,7 +5464,7 @@ void EsterelParser::variableDeclList() {
 			match(COMMA);
 			variableDecls();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -5477,52 +5477,52 @@ void EsterelParser::variableDeclList() {
 	if ( inputState->guessing==0 ) {
 		variableDeclList_AST = RefLineAST(currentAST.root);
 #line 628 "esterel.g"
-		variableDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(VARS,"vars")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(variableDeclList_AST))));
+		variableDeclList_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(VARS,"vars")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(variableDeclList_AST))));
 #line 5482 "EsterelParser.cpp"
 		currentAST.root = variableDeclList_AST;
-		if ( variableDeclList_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			variableDeclList_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( variableDeclList_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			variableDeclList_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = variableDeclList_AST->getFirstChild();
 		else
 			currentAST.child = variableDeclList_AST;
 		currentAST.advanceChildToEnd();
 	}
-	variableDeclList_AST = static_cast<RefLineAST>(currentAST.root);
+	variableDeclList_AST = RefLineAST(currentAST.root);
 	returnAST = variableDeclList_AST;
 }
 
 void EsterelParser::variableDecls() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableDecls_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableDecls_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	variableDeclList2();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	RefLineAST tmp248_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp248_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp248_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp248_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp248_AST));
 	}
 	match(COLON);
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	variableDecls_AST = static_cast<RefLineAST>(currentAST.root);
+	variableDecls_AST = RefLineAST(currentAST.root);
 	returnAST = variableDecls_AST;
 }
 
 void EsterelParser::variableDeclList2() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableDeclList2_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableDeclList2_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	variableDecl();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{ // ( ... )*
 	for (;;) {
@@ -5530,7 +5530,7 @@ void EsterelParser::variableDeclList2() {
 			match(COMMA);
 			variableDecl();
 			if (inputState->guessing==0) {
-				astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+				astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 			}
 		}
 		else {
@@ -5544,28 +5544,28 @@ void EsterelParser::variableDeclList2() {
 	if ( inputState->guessing==0 ) {
 		variableDeclList2_AST = RefLineAST(currentAST.root);
 #line 642 "esterel.g"
-		variableDeclList2_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(VARS,"vars")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(variableDeclList2_AST))));
+		variableDeclList2_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(VARS,"vars")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(variableDeclList2_AST))));
 #line 5549 "EsterelParser.cpp"
 		currentAST.root = variableDeclList2_AST;
-		if ( variableDeclList2_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			variableDeclList2_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( variableDeclList2_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			variableDeclList2_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = variableDeclList2_AST->getFirstChild();
 		else
 			currentAST.child = variableDeclList2_AST;
 		currentAST.advanceChildToEnd();
 	}
-	variableDeclList2_AST = static_cast<RefLineAST>(currentAST.root);
+	variableDeclList2_AST = RefLineAST(currentAST.root);
 	returnAST = variableDeclList2_AST;
 }
 
 void EsterelParser::variableDecl() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableDecl_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableDecl_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	variableIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	{
 	switch ( LA(1)) {
@@ -5573,7 +5573,7 @@ void EsterelParser::variableDecl() {
 	{
 		variableInitializer();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -5591,43 +5591,43 @@ void EsterelParser::variableDecl() {
 	if ( inputState->guessing==0 ) {
 		variableDecl_AST = RefLineAST(currentAST.root);
 #line 649 "esterel.g"
-		variableDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(VDECL,"vdecl")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(variableDecl_AST))));
+		variableDecl_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(VDECL,"vdecl")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(variableDecl_AST))));
 #line 5596 "EsterelParser.cpp"
 		currentAST.root = variableDecl_AST;
-		if ( variableDecl_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			variableDecl_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( variableDecl_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			variableDecl_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = variableDecl_AST->getFirstChild();
 		else
 			currentAST.child = variableDecl_AST;
 		currentAST.advanceChildToEnd();
 	}
-	variableDecl_AST = static_cast<RefLineAST>(currentAST.root);
+	variableDecl_AST = RefLineAST(currentAST.root);
 	returnAST = variableDecl_AST;
 }
 
 void EsterelParser::variableInitializer() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST variableInitializer_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableInitializer_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
-	RefLineAST tmp250_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tmp250_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	if ( inputState->guessing == 0 ) {
 		tmp250_AST = astFactory->create(LT(1));
-		astFactory->makeASTRoot(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp250_AST));
+		astFactory->makeASTRoot(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp250_AST));
 	}
 	match(COLEQUALS);
 	expression();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
-	variableInitializer_AST = static_cast<RefLineAST>(currentAST.root);
+	variableInitializer_AST = RefLineAST(currentAST.root);
 	returnAST = variableInitializer_AST;
 }
 
 void EsterelParser::renaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST renaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST renaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_type:
@@ -5635,7 +5635,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_type);
 		typeRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5643,7 +5643,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				typeRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5653,7 +5653,7 @@ void EsterelParser::renaming() {
 		}
 		_loop246:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_constant:
@@ -5661,7 +5661,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_constant);
 		constantRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5669,7 +5669,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				constantRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5679,7 +5679,7 @@ void EsterelParser::renaming() {
 		}
 		_loop248:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_function:
@@ -5687,7 +5687,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_function);
 		functionRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5695,7 +5695,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				functionRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5705,7 +5705,7 @@ void EsterelParser::renaming() {
 		}
 		_loop250:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_procedure:
@@ -5713,7 +5713,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_procedure);
 		procedureRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5721,7 +5721,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				procedureRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5731,7 +5731,7 @@ void EsterelParser::renaming() {
 		}
 		_loop252:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_task:
@@ -5739,7 +5739,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_task);
 		taskRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5747,7 +5747,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				taskRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5757,7 +5757,7 @@ void EsterelParser::renaming() {
 		}
 		_loop254:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_signal:
@@ -5765,7 +5765,7 @@ void EsterelParser::renaming() {
 		match(LITERAL_signal);
 		signalRenaming();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		{ // ( ... )*
 		for (;;) {
@@ -5773,7 +5773,7 @@ void EsterelParser::renaming() {
 				match(COMMA);
 				signalRenaming();
 				if (inputState->guessing==0) {
-					astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+					astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 				}
 			}
 			else {
@@ -5783,7 +5783,7 @@ void EsterelParser::renaming() {
 		}
 		_loop256:;
 		} // ( ... )*
-		renaming_AST = static_cast<RefLineAST>(currentAST.root);
+		renaming_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -5795,71 +5795,71 @@ void EsterelParser::renaming() {
 }
 
 void EsterelParser::typeRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST typeRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(SLASH);
 	typeIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		typeRenaming_AST = RefLineAST(currentAST.root);
 #line 678 "esterel.g"
-		typeRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TRENAME,"trename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(typeRenaming_AST))));
+		typeRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TRENAME,"trename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(typeRenaming_AST))));
 #line 5816 "EsterelParser.cpp"
 		currentAST.root = typeRenaming_AST;
-		if ( typeRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			typeRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( typeRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			typeRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = typeRenaming_AST->getFirstChild();
 		else
 			currentAST.child = typeRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	typeRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	typeRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = typeRenaming_AST;
 }
 
 void EsterelParser::constantRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST constantRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	constantAtom();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(SLASH);
 	constantIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		constantRenaming_AST = RefLineAST(currentAST.root);
 #line 683 "esterel.g"
-		constantRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(CRENAME,"crename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(constantRenaming_AST))));
+		constantRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(CRENAME,"crename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(constantRenaming_AST))));
 #line 5847 "EsterelParser.cpp"
 		currentAST.root = constantRenaming_AST;
-		if ( constantRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			constantRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( constantRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			constantRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = constantRenaming_AST->getFirstChild();
 		else
 			currentAST.child = constantRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	constantRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	constantRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = constantRenaming_AST;
 }
 
 void EsterelParser::functionRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST functionRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	{
 	switch ( LA(1)) {
@@ -5867,12 +5867,12 @@ void EsterelParser::functionRenaming() {
 	{
 		functionIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(SLASH);
 		functionIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -5893,12 +5893,12 @@ void EsterelParser::functionRenaming() {
 	{
 		predefinedFunction();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		match(SLASH);
 		functionIdentifier();
 		if (inputState->guessing==0) {
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 		}
 		break;
 	}
@@ -5911,271 +5911,271 @@ void EsterelParser::functionRenaming() {
 	if ( inputState->guessing==0 ) {
 		functionRenaming_AST = RefLineAST(currentAST.root);
 #line 689 "esterel.g"
-		functionRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(FRENAME,"frename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(functionRenaming_AST))));
+		functionRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(FRENAME,"frename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(functionRenaming_AST))));
 #line 5916 "EsterelParser.cpp"
 		currentAST.root = functionRenaming_AST;
-		if ( functionRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			functionRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( functionRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			functionRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = functionRenaming_AST->getFirstChild();
 		else
 			currentAST.child = functionRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	functionRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	functionRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = functionRenaming_AST;
 }
 
 void EsterelParser::procedureRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST procedureRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	procedureIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(SLASH);
 	procedureIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		procedureRenaming_AST = RefLineAST(currentAST.root);
 #line 712 "esterel.g"
-		procedureRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(PRENAME,"prename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(procedureRenaming_AST))));
+		procedureRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(PRENAME,"prename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(procedureRenaming_AST))));
 #line 5947 "EsterelParser.cpp"
 		currentAST.root = procedureRenaming_AST;
-		if ( procedureRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			procedureRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( procedureRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			procedureRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = procedureRenaming_AST->getFirstChild();
 		else
 			currentAST.child = procedureRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	procedureRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	procedureRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = procedureRenaming_AST;
 }
 
 void EsterelParser::taskRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST taskRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	taskIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(SLASH);
 	taskIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		taskRenaming_AST = RefLineAST(currentAST.root);
 #line 717 "esterel.g"
-		taskRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(TARENAME,"trename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(taskRenaming_AST))));
+		taskRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(TARENAME,"trename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(taskRenaming_AST))));
 #line 5978 "EsterelParser.cpp"
 		currentAST.root = taskRenaming_AST;
-		if ( taskRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			taskRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( taskRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			taskRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = taskRenaming_AST->getFirstChild();
 		else
 			currentAST.child = taskRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	taskRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	taskRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = taskRenaming_AST;
 }
 
 void EsterelParser::signalRenaming() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST signalRenaming_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalRenaming_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	match(SLASH);
 	signalIdentifier();
 	if (inputState->guessing==0) {
-		astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(returnAST));
+		astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST));
 	}
 	if ( inputState->guessing==0 ) {
 		signalRenaming_AST = RefLineAST(currentAST.root);
 #line 723 "esterel.g"
-		signalRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(astFactory->create(SRENAME,"srename")))->add(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(signalRenaming_AST))));
+		signalRenaming_AST = RefLineAST(astFactory->make((new ANTLR_USE_NAMESPACE(antlr)ASTArray(2))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(astFactory->create(SRENAME,"srename")))->add(ANTLR_USE_NAMESPACE(antlr)RefAST(signalRenaming_AST))));
 #line 6009 "EsterelParser.cpp"
 		currentAST.root = signalRenaming_AST;
-		if ( signalRenaming_AST!=static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
-			signalRenaming_AST->getFirstChild() != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( signalRenaming_AST!=RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) &&
+			signalRenaming_AST->getFirstChild() != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			  currentAST.child = signalRenaming_AST->getFirstChild();
 		else
 			currentAST.child = signalRenaming_AST;
 		currentAST.advanceChildToEnd();
 	}
-	signalRenaming_AST = static_cast<RefLineAST>(currentAST.root);
+	signalRenaming_AST = RefLineAST(currentAST.root);
 	returnAST = signalRenaming_AST;
 }
 
 void EsterelParser::predefinedFunction() {
-	returnAST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	returnAST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
-	RefLineAST predefinedFunction_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST predefinedFunction_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	switch ( LA(1)) {
 	case LITERAL_and:
 	{
-		RefLineAST tmp270_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp270_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp270_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp270_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp270_AST));
 		}
 		match(LITERAL_and);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_or:
 	{
-		RefLineAST tmp271_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp271_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp271_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp271_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp271_AST));
 		}
 		match(LITERAL_or);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_not:
 	{
-		RefLineAST tmp272_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp272_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp272_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp272_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp272_AST));
 		}
 		match(LITERAL_not);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case PLUS:
 	{
-		RefLineAST tmp273_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp273_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp273_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp273_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp273_AST));
 		}
 		match(PLUS);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case DASH:
 	{
-		RefLineAST tmp274_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp274_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp274_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp274_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp274_AST));
 		}
 		match(DASH);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case STAR:
 	{
-		RefLineAST tmp275_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp275_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp275_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp275_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp275_AST));
 		}
 		match(STAR);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case SLASH:
 	{
-		RefLineAST tmp276_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp276_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp276_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp276_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp276_AST));
 		}
 		match(SLASH);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LITERAL_mod:
 	{
-		RefLineAST tmp277_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp277_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp277_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp277_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp277_AST));
 		}
 		match(LITERAL_mod);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LESSTHAN:
 	{
-		RefLineAST tmp278_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp278_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp278_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp278_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp278_AST));
 		}
 		match(LESSTHAN);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case GREATERTHAN:
 	{
-		RefLineAST tmp279_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp279_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp279_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp279_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp279_AST));
 		}
 		match(GREATERTHAN);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case LEQUAL:
 	{
-		RefLineAST tmp280_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp280_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp280_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp280_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp280_AST));
 		}
 		match(LEQUAL);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case GEQUAL:
 	{
-		RefLineAST tmp281_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp281_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp281_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp281_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp281_AST));
 		}
 		match(GEQUAL);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case NEQUAL:
 	{
-		RefLineAST tmp282_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp282_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp282_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp282_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp282_AST));
 		}
 		match(NEQUAL);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	case EQUALS:
 	{
-		RefLineAST tmp283_AST = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+		RefLineAST tmp283_AST = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 		if ( inputState->guessing == 0 ) {
 			tmp283_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(tmp283_AST));
+			astFactory->addASTChild(currentAST, ANTLR_USE_NAMESPACE(antlr)RefAST(tmp283_AST));
 		}
 		match(EQUALS);
-		predefinedFunction_AST = static_cast<RefLineAST>(currentAST.root);
+		predefinedFunction_AST = RefLineAST(currentAST.root);
 		break;
 	}
 	default:
@@ -6184,11 +6184,6 @@ void EsterelParser::predefinedFunction() {
 	}
 	}
 	returnAST = predefinedFunction_AST;
-}
-
-RefLineAST EsterelParser::getAST()
-{
-	return returnAST;
 }
 
 void EsterelParser::initializeASTFactory( ANTLR_USE_NAMESPACE(antlr)ASTFactory& factory )

--- a/src/EsterelParser.hpp
+++ b/src/EsterelParser.hpp
@@ -2,7 +2,7 @@
 #define INC_EsterelParser_hpp_
 
 #include <antlr/config.hpp>
-/* $ANTLR 2.7.2: "esterel.g" -> "EsterelParser.hpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "esterel.g" -> "EsterelParser.hpp"$ */
 #include <antlr/TokenStream.hpp>
 #include <antlr/TokenBuffer.hpp>
 #include "EsterelTokenTypes.hpp"
@@ -26,7 +26,7 @@
  *
  * Change Log
  */
-class EsterelParser : public ANTLR_USE_NAMESPACE(antlr)LLkParser, public EsterelTokenTypes
+class CUSTOM_API EsterelParser : public ANTLR_USE_NAMESPACE(antlr)LLkParser, public EsterelTokenTypes
 {
 #line 1 "esterel.g"
 #line 33 "EsterelParser.hpp"
@@ -170,7 +170,10 @@ public:
 	public: void signalRenaming();
 	public: void predefinedFunction();
 public:
-	RefLineAST getAST();
+	ANTLR_USE_NAMESPACE(antlr)RefAST getAST()
+	{
+		return ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST);
+	}
 	
 protected:
 	RefLineAST returnAST;

--- a/src/EsterelTokenTypes.hpp
+++ b/src/EsterelTokenTypes.hpp
@@ -1,8 +1,15 @@
 #ifndef INC_EsterelTokenTypes_hpp_
 #define INC_EsterelTokenTypes_hpp_
 
-/* $ANTLR 2.7.2: "esterel.g" -> "EsterelTokenTypes.hpp"$ */
-struct EsterelTokenTypes {
+/* $ANTLR 2.7.7 (2006-11-01): "esterel.g" -> "EsterelTokenTypes.hpp"$ */
+
+#ifndef CUSTOM_API
+# define CUSTOM_API
+#endif
+
+#ifdef __cplusplus
+struct CUSTOM_API EsterelTokenTypes {
+#endif
 	enum {
 		EOF_ = 1,
 		SIGS = 4,
@@ -128,5 +135,7 @@ struct EsterelTokenTypes {
 		Comment = 124,
 		NULL_TREE_LOOKAHEAD = 3
 	};
+#ifdef __cplusplus
 };
+#endif
 #endif /*INC_EsterelTokenTypes_hpp_*/

--- a/src/EsterelTreeParser.cpp
+++ b/src/EsterelTreeParser.cpp
@@ -1,4 +1,4 @@
-/* $ANTLR 2.7.2: "staticsemantics.g" -> "EsterelTreeParser.cpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "staticsemantics.g" -> "EsterelTreeParser.cpp"$ */
 #include "EsterelTreeParser.hpp"
 #include <antlr/Token.hpp>
 #include <antlr/AST.hpp>
@@ -91,7 +91,7 @@ EsterelTreeParser::EsterelTreeParser()
 void EsterelTreeParser::file(RefLineAST _t,
 	Modules *ms, string filename
 ) {
-	RefLineAST file_AST_in = _t;
+	RefLineAST file_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 	
 	try {      // for error handling
 #line 129 "staticsemantics.g"
@@ -102,14 +102,14 @@ void EsterelTreeParser::file(RefLineAST _t,
 		{ // ( ... )+
 		int _cnt3=0;
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == LITERAL_module)) {
 				module(_t,ms);
 				_t = _retTree;
 			}
 			else {
-				if ( _cnt3>=1 ) { goto _loop3; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+				if ( _cnt3>=1 ) { goto _loop3; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 			}
 			
 			_cnt3++;
@@ -119,7 +119,7 @@ void EsterelTreeParser::file(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -128,16 +128,16 @@ void EsterelTreeParser::file(RefLineAST _t,
 void EsterelTreeParser::module(RefLineAST _t,
 	Modules* modules
 ) {
-	RefLineAST module_AST_in = _t;
-	RefLineAST moduleName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST module_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST moduleName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t5 = _t;
 		RefLineAST tmp1_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_module);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_module);
 		_t = _t->getFirstChild();
 		moduleName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 137 "staticsemantics.g"
 		
@@ -203,7 +203,7 @@ void EsterelTreeParser::module(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -212,35 +212,35 @@ void EsterelTreeParser::module(RefLineAST _t,
 void EsterelTreeParser::declarations(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST declarations_AST_in = _t;
+	RefLineAST declarations_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 	
 	try {      // for error handling
 		RefLineAST __t7 = _t;
 		RefLineAST tmp2_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DECLS);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DECLS);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_type:
 			{
 				RefLineAST __t9 = _t;
 				RefLineAST tmp3_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_type);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_type);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt11=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == ID)) {
 						typeDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt11>=1 ) { goto _loop11; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt11>=1 ) { goto _loop11; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt11++;
@@ -255,19 +255,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t12 = _t;
 				RefLineAST tmp4_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_constant);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_constant);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt14=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == CDECL)) {
 						constantDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt14>=1 ) { goto _loop14; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt14>=1 ) { goto _loop14; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt14++;
@@ -282,19 +282,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t15 = _t;
 				RefLineAST tmp5_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_input);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_input);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt17=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == SDECL)) {
 						signalDecl(_t,c, "input", true);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt17>=1 ) { goto _loop17; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt17>=1 ) { goto _loop17; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt17++;
@@ -309,19 +309,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t18 = _t;
 				RefLineAST tmp6_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_output);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_output);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt20=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == SDECL)) {
 						signalDecl(_t,c, "output", true );
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt20>=1 ) { goto _loop20; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt20>=1 ) { goto _loop20; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt20++;
@@ -336,19 +336,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t21 = _t;
 				RefLineAST tmp7_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_inputoutput);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_inputoutput);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt23=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == SDECL)) {
 						signalDecl(_t,c, "inputoutput", true);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt23>=1 ) { goto _loop23; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt23>=1 ) { goto _loop23; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt23++;
@@ -363,19 +363,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t24 = _t;
 				RefLineAST tmp8_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_return);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_return);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt26=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == SDECL)) {
 						signalDecl(_t,c, "return", true);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt26>=1 ) { goto _loop26; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt26>=1 ) { goto _loop26; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt26++;
@@ -390,19 +390,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t27 = _t;
 				RefLineAST tmp9_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_function);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_function);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt29=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == FDECL)) {
 						functionDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt29>=1 ) { goto _loop29; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt29>=1 ) { goto _loop29; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt29++;
@@ -417,19 +417,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t30 = _t;
 				RefLineAST tmp10_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_procedure);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_procedure);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt32=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == PDECL)) {
 						procedureDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt32>=1 ) { goto _loop32; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt32>=1 ) { goto _loop32; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt32++;
@@ -444,19 +444,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t33 = _t;
 				RefLineAST tmp11_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_task);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_task);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt35=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == TADECL)) {
 						taskDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt35>=1 ) { goto _loop35; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt35>=1 ) { goto _loop35; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt35++;
@@ -471,19 +471,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t36 = _t;
 				RefLineAST tmp12_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_sensor);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_sensor);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt38=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == SDECL)) {
 						signalDecl(_t,c, "sensor", true);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt38>=1 ) { goto _loop38; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt38>=1 ) { goto _loop38; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt38++;
@@ -498,19 +498,19 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 			{
 				RefLineAST __t39 = _t;
 				RefLineAST tmp13_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_relation);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_relation);
 				_t = _t->getFirstChild();
 				{ // ( ... )+
 				int _cnt41=0;
 				for (;;) {
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					if ((_t->getType() == IMPLIES || _t->getType() == POUND)) {
 						relationDecl(_t,c);
 						_t = _retTree;
 					}
 					else {
-						if ( _cnt41>=1 ) { goto _loop41; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+						if ( _cnt41>=1 ) { goto _loop41; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 					}
 					
 					_cnt41++;
@@ -534,7 +534,7 @@ void EsterelTreeParser::declarations(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -546,46 +546,46 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 414 "staticsemantics.g"
 	Statement *st;
 #line 549 "EsterelTreeParser.cpp"
-	RefLineAST statement_AST_in = _t;
-	RefLineAST esig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST ssig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST var = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST proc = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST ife = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST elif = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST expr = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST etrap = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST texpr = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST taskid = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST tsig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST vdecls = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST module = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST oldMod = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST tID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST cID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST func = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST fID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST pro = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST pID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST task = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST trID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST sig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST sID = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST de = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST statement_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST esig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST ssig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST var = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST proc = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST ife = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST elif = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST expr = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST etrap = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST texpr = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskid = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tsig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST vdecls = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST module = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST oldMod = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST tID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST cID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST func = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST fID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST pro = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST pID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST task = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sID = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST de = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 415 "staticsemantics.g"
 		st = 0;
 #line 580 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case SEQUENCE:
 		{
 			RefLineAST __t93 = _t;
 			RefLineAST tmp14_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SEQUENCE);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SEQUENCE);
 			_t = _t->getFirstChild();
 #line 416 "staticsemantics.g"
 			StatementList *sl = new StatementList();
@@ -593,7 +593,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt95=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_tokenSet_0.member(_t->getType()))) {
 					st=statement(_t,c);
@@ -603,7 +603,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 604 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt95>=1 ) { goto _loop95; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt95>=1 ) { goto _loop95; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt95++;
@@ -621,7 +621,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t96 = _t;
 			RefLineAST tmp15_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PARALLEL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PARALLEL);
 			_t = _t->getFirstChild();
 #line 421 "staticsemantics.g"
 			ParallelStatementList *sl = new ParallelStatementList();
@@ -629,7 +629,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt98=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_tokenSet_0.member(_t->getType()))) {
 					st=statement(_t,c);
@@ -639,7 +639,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 640 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt98>=1 ) { goto _loop98; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt98>=1 ) { goto _loop98; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt98++;
@@ -656,7 +656,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		case LITERAL_nothing:
 		{
 			RefLineAST tmp16_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_nothing);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_nothing);
 			_t = _t->getNextSibling();
 #line 425 "staticsemantics.g"
 			st = new Nothing();
@@ -666,7 +666,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		case LITERAL_pause:
 		{
 			RefLineAST tmp17_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_pause);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_pause);
 			_t = _t->getNextSibling();
 #line 427 "staticsemantics.g"
 			st = new Pause();
@@ -676,7 +676,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		case LITERAL_halt:
 		{
 			RefLineAST tmp18_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_halt);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_halt);
 			_t = _t->getNextSibling();
 #line 429 "staticsemantics.g"
 			st = new Halt();
@@ -687,10 +687,10 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t99 = _t;
 			RefLineAST tmp19_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_emit);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_emit);
 			_t = _t->getFirstChild();
 			esig = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 433 "staticsemantics.g"
 			
@@ -704,7 +704,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			
 #line 706 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case CALL:
@@ -743,7 +743,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -767,10 +767,10 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t101 = _t;
 			RefLineAST tmp20_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_sustain);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_sustain);
 			_t = _t->getFirstChild();
 			ssig = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 457 "staticsemantics.g"
 			
@@ -784,7 +784,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			
 #line 786 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case CALL:
@@ -823,7 +823,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -850,10 +850,10 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 851 "EsterelTreeParser.cpp"
 			RefLineAST __t103 = _t;
 			RefLineAST tmp21_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COLEQUALS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COLEQUALS);
 			_t = _t->getFirstChild();
 			var = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			e=expression(_t,c);
 			_t = _retTree;
@@ -882,10 +882,10 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t104 = _t;
 			RefLineAST tmp22_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_call);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_call);
 			_t = _t->getFirstChild();
 			proc = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 498 "staticsemantics.g"
 			
@@ -911,19 +911,19 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t105 = _t;
 			RefLineAST tmp23_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_present);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_present);
 			_t = _t->getFirstChild();
 #line 511 "staticsemantics.g"
 			Present *p = new Present();
 #line 919 "EsterelTreeParser.cpp"
 			{ // ( ... )*
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == CASE)) {
 					RefLineAST __t107 = _t;
 					RefLineAST tmp24_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CASE);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CASE);
 					_t = _t->getFirstChild();
 #line 512 "staticsemantics.g"
 					Expression *e; Statement *s = 0;
@@ -931,7 +931,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					e=sigExpression(_t,c);
 					_t = _retTree;
 					{
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					switch ( _t->getType()) {
 					case SEQUENCE:
@@ -970,7 +970,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					}
 					default:
 					{
-						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 					}
 					}
 					}
@@ -988,14 +988,14 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			_loop109:;
 			} // ( ... )*
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_else:
 			{
 				RefLineAST __t111 = _t;
 				RefLineAST tmp25_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_else);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_else);
 				_t = _t->getFirstChild();
 #line 515 "staticsemantics.g"
 				Statement *s;
@@ -1015,7 +1015,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1030,26 +1030,26 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t112 = _t;
 			RefLineAST tmp26_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_if);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_if);
 			_t = _t->getFirstChild();
 #line 523 "staticsemantics.g"
 			If *i = new If(); Expression *e;
 #line 1038 "EsterelTreeParser.cpp"
-			ife = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			ife = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			e=expression(_t,c);
 			_t = _retTree;
 #line 525 "staticsemantics.g"
 			Statement *s = 0;
 #line 1044 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_then:
 			{
 				RefLineAST __t114 = _t;
 				RefLineAST tmp27_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_then);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_then);
 				_t = _t->getFirstChild();
 				s=statement(_t,c);
 				_t = _retTree;
@@ -1065,7 +1065,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1074,12 +1074,12 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1075 "EsterelTreeParser.cpp"
 			{ // ( ... )*
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == LITERAL_elsif)) {
 					RefLineAST __t116 = _t;
-					elif = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_elsif);
+					elif = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_elsif);
 					_t = _t->getFirstChild();
 					e=expression(_t,c);
 					_t = _retTree;
@@ -1099,14 +1099,14 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			_loop117:;
 			} // ( ... )*
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_else:
 			{
 				RefLineAST __t119 = _t;
 				RefLineAST tmp28_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_else);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_else);
 				_t = _t->getFirstChild();
 				s=statement(_t,c);
 				_t = _retTree;
@@ -1123,7 +1123,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1138,7 +1138,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t120 = _t;
 			RefLineAST tmp29_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_loop);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_loop);
 			_t = _t->getFirstChild();
 #line 535 "staticsemantics.g"
 			Statement *s; Expression *e;
@@ -1146,7 +1146,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			s=statement(_t,c);
 			_t = _retTree;
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case 3:
@@ -1173,7 +1173,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1185,19 +1185,19 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t122 = _t;
 			RefLineAST tmp30_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_repeat);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_repeat);
 			_t = _t->getFirstChild();
 #line 542 "staticsemantics.g"
 			bool positive = false; Expression *e;
 #line 1193 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_positive:
 			{
 				RefLineAST tmp31_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_positive);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_positive);
 				_t = _t->getNextSibling();
 #line 543 "staticsemantics.g"
 				positive = true;
@@ -1234,11 +1234,11 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
-			expr = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			expr = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			e=expression(_t,c);
 			_t = _retTree;
 #line 545 "staticsemantics.g"
@@ -1266,19 +1266,19 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t124 = _t;
 			RefLineAST tmp32_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_abort);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_abort);
 			_t = _t->getFirstChild();
 #line 559 "staticsemantics.g"
 			bool isWeak = false; Statement *s;
 #line 1274 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case LITERAL_weak:
 			{
 				RefLineAST tmp33_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_weak);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_weak);
 				_t = _t->getNextSibling();
 #line 560 "staticsemantics.g"
 				isWeak = true;
@@ -1315,7 +1315,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1327,12 +1327,12 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt129=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == CASE)) {
 					RefLineAST __t127 = _t;
 					RefLineAST tmp34_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CASE);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CASE);
 					_t = _t->getFirstChild();
 #line 563 "staticsemantics.g"
 					Expression *e; s = 0;
@@ -1340,7 +1340,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					e=delayExpression(_t,c);
 					_t = _retTree;
 					{
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					switch ( _t->getType()) {
 					case SEQUENCE:
@@ -1379,7 +1379,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					}
 					default:
 					{
-						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 					}
 					}
 					}
@@ -1390,7 +1390,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1391 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt129>=1 ) { goto _loop129; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt129>=1 ) { goto _loop129; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt129++;
@@ -1408,7 +1408,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t130 = _t;
 			RefLineAST tmp35_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_await);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_await);
 			_t = _t->getFirstChild();
 #line 569 "staticsemantics.g"
 			Await *a = new Await();
@@ -1416,12 +1416,12 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt134=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == CASE)) {
 					RefLineAST __t132 = _t;
 					RefLineAST tmp36_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CASE);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CASE);
 					_t = _t->getFirstChild();
 #line 570 "staticsemantics.g"
 					Expression *e; Statement *s = 0;
@@ -1429,7 +1429,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					e=delayExpression(_t,c);
 					_t = _retTree;
 					{
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					switch ( _t->getType()) {
 					case SEQUENCE:
@@ -1468,7 +1468,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					}
 					default:
 					{
-						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 					}
 					}
 					}
@@ -1479,7 +1479,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1480 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt134>=1 ) { goto _loop134; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt134>=1 ) { goto _loop134; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt134++;
@@ -1497,7 +1497,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t135 = _t;
 			RefLineAST tmp37_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_every);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_every);
 			_t = _t->getFirstChild();
 #line 576 "staticsemantics.g"
 			Expression *e; Statement *s;
@@ -1517,7 +1517,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t136 = _t;
 			RefLineAST tmp38_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_suspend);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_suspend);
 			_t = _t->getFirstChild();
 #line 581 "staticsemantics.g"
 			Expression *e; Statement *s;
@@ -1537,7 +1537,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t137 = _t;
 			RefLineAST tmp39_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_trap);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_trap);
 			_t = _t->getFirstChild();
 #line 587 "staticsemantics.g"
 			
@@ -1552,19 +1552,19 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1553 "EsterelTreeParser.cpp"
 			RefLineAST __t138 = _t;
 			RefLineAST tmp40_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TRAPS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TRAPS);
 			_t = _t->getFirstChild();
 			{ // ( ... )+
 			int _cnt140=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == TDECL)) {
 					trapDecl(_t,&nc);
 					_t = _retTree;
 				}
 				else {
-					if ( _cnt140>=1 ) { goto _loop140; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt140>=1 ) { goto _loop140; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt140++;
@@ -1580,12 +1580,12 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1581 "EsterelTreeParser.cpp"
 			{ // ( ... )*
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == LITERAL_handle)) {
 					RefLineAST __t142 = _t;
 					RefLineAST tmp41_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_handle);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_handle);
 					_t = _t->getFirstChild();
 					e=trapExpression(_t,&nc);
 					_t = _retTree;
@@ -1615,16 +1615,16 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t144 = _t;
 			RefLineAST tmp42_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_exit);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_exit);
 			_t = _t->getFirstChild();
 			etrap = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 606 "staticsemantics.g"
 			Expression *e = 0;
 #line 1626 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case CALL:
@@ -1653,7 +1653,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			case LITERAL_false:
 			case StringConstant:
 			{
-				texpr = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+				texpr = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 				e=expression(_t,c);
 				_t = _retTree;
 				break;
@@ -1664,7 +1664,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -1697,7 +1697,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t146 = _t;
 			RefLineAST tmp43_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_exec);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_exec);
 			_t = _t->getFirstChild();
 #line 628 "staticsemantics.g"
 			Exec *ex = new Exec();
@@ -1705,15 +1705,15 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt150=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == CASE)) {
 					RefLineAST __t148 = _t;
 					RefLineAST tmp44_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CASE);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CASE);
 					_t = _t->getFirstChild();
 					taskid = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 630 "staticsemantics.g"
 					
@@ -1729,7 +1729,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					procArgs(_t,c, tc);
 					_t = _retTree;
 					tsig = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 641 "staticsemantics.g"
 					
@@ -1745,7 +1745,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					
 #line 1747 "EsterelTreeParser.cpp"
 					{
-					if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+					if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 						_t = ASTNULL;
 					switch ( _t->getType()) {
 					case SEQUENCE:
@@ -1787,7 +1787,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					}
 					default:
 					{
-						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+						throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 					}
 					}
 					}
@@ -1795,7 +1795,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					_t = _t->getNextSibling();
 				}
 				else {
-					if ( _cnt150>=1 ) { goto _loop150; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt150>=1 ) { goto _loop150; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt150++;
@@ -1813,7 +1813,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t151 = _t;
 			RefLineAST tmp45_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_var);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_var);
 			_t = _t->getFirstChild();
 #line 659 "staticsemantics.g"
 			
@@ -1827,20 +1827,20 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1828 "EsterelTreeParser.cpp"
 			RefLineAST __t152 = _t;
 			RefLineAST tmp46_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),VARS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),VARS);
 			_t = _t->getFirstChild();
 			{ // ( ... )+
 			int _cnt155=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == COLON)) {
 					RefLineAST __t154 = _t;
 					RefLineAST tmp47_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COLON);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COLON);
 					_t = _t->getFirstChild();
 					vdecls = _t;
-					if ( _t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) ) throw ANTLR_USE_NAMESPACE(antlr)MismatchedTokenException();
+					if ( _t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) ) throw ANTLR_USE_NAMESPACE(antlr)MismatchedTokenException();
 					_t = _t->getNextSibling();
 					ts=type(_t,c);
 					_t = _retTree;
@@ -1851,7 +1851,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1852 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt155>=1 ) { goto _loop155; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt155>=1 ) { goto _loop155; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt155++;
@@ -1879,7 +1879,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t156 = _t;
 			RefLineAST tmp48_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_signal);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_signal);
 			_t = _t->getFirstChild();
 #line 681 "staticsemantics.g"
 			
@@ -1891,19 +1891,19 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 #line 1892 "EsterelTreeParser.cpp"
 			RefLineAST __t157 = _t;
 			RefLineAST tmp49_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SIGS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SIGS);
 			_t = _t->getFirstChild();
 			{ // ( ... )+
 			int _cnt159=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == SDECL)) {
 					signalDecl(_t,&nc, "local", false);
 					_t = _retTree;
 				}
 				else {
-					if ( _cnt159>=1 ) { goto _loop159; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt159>=1 ) { goto _loop159; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt159++;
@@ -1931,22 +1931,22 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t160 = _t;
 			RefLineAST tmp50_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),RUN);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),RUN);
 			_t = _t->getFirstChild();
 			module = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 696 "staticsemantics.g"
 			Run *r = new Run(module->getText(), c->signals);
 #line 1942 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case ID:
 			{
 				oldMod = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 				_t = _t->getNextSibling();
 #line 697 "staticsemantics.g"
 				r->old_name = oldMod->getText();
@@ -1965,20 +1965,20 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
 			{ // ( ... )*
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				switch ( _t->getType()) {
 				case TRENAME:
 				{
 					RefLineAST __t163 = _t;
 					RefLineAST tmp51_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TRENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TRENAME);
 					_t = _t->getFirstChild();
 #line 698 "staticsemantics.g"
 					TypeSymbol *t;
@@ -1986,7 +1986,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					t=type(_t,c);
 					_t = _retTree;
 					tID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 					_t = __t163;
 					_t = _t->getNextSibling();
@@ -1999,7 +1999,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 				{
 					RefLineAST __t164 = _t;
 					RefLineAST tmp52_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CRENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CRENAME);
 					_t = _t->getFirstChild();
 #line 700 "staticsemantics.g"
 					Expression *e;
@@ -2007,7 +2007,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 					e=expression(_t,c);
 					_t = _retTree;
 					cID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 					_t = __t164;
 					_t = _t->getNextSibling();
@@ -2021,13 +2021,13 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 				{
 					RefLineAST __t165 = _t;
 					RefLineAST tmp53_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),FRENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),FRENAME);
 					_t = _t->getFirstChild();
-					func = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+					func = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 					funcName(_t);
 					_t = _retTree;
 					fID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 704 "staticsemantics.g"
 					
@@ -2048,13 +2048,13 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 				{
 					RefLineAST __t166 = _t;
 					RefLineAST tmp54_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PRENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PRENAME);
 					_t = _t->getFirstChild();
 					pro = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 					pID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 715 "staticsemantics.g"
 					
@@ -2076,13 +2076,13 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 				{
 					RefLineAST __t167 = _t;
 					RefLineAST tmp55_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TARENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TARENAME);
 					_t = _t->getFirstChild();
 					task = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 					trID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 727 "staticsemantics.g"
 					
@@ -2104,13 +2104,13 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 				{
 					RefLineAST __t168 = _t;
 					RefLineAST tmp56_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SRENAME);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SRENAME);
 					_t = _t->getFirstChild();
 					sig = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 					sID = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 739 "staticsemantics.g"
 					
@@ -2146,18 +2146,18 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t170 = _t;
 			RefLineAST tmp57_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DOWATCHING);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DOWATCHING);
 			_t = _t->getFirstChild();
 #line 753 "staticsemantics.g"
 			Expression *e; Statement *s1, *s2 = 0;
 #line 2154 "EsterelTreeParser.cpp"
 			s1=statement(_t,c);
 			_t = _retTree;
-			de = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			de = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			e=delayExpression(_t,c);
 			_t = _retTree;
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case SEQUENCE:
@@ -2196,7 +2196,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -2211,7 +2211,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		{
 			RefLineAST __t172 = _t;
 			RefLineAST tmp58_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DOUPTO);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DOUPTO);
 			_t = _t->getFirstChild();
 #line 760 "staticsemantics.g"
 			Expression *e; Statement *s;
@@ -2229,7 +2229,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -2241,7 +2241,7 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2251,12 +2251,12 @@ Statement * EsterelTreeParser::statement(RefLineAST _t,
 void EsterelTreeParser::typeDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST typeDecl_AST_in = _t;
-	RefLineAST typeName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST typeName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		typeName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 211 "staticsemantics.g"
 		
@@ -2269,7 +2269,7 @@ void EsterelTreeParser::typeDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2278,11 +2278,11 @@ void EsterelTreeParser::typeDecl(RefLineAST _t,
 void EsterelTreeParser::constantDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST constantDecl_AST_in = _t;
-	RefLineAST constantName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST expr = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST typeToken = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST ids = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST constantDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST constantName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST expr = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeToken = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST ids = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 #line 219 "staticsemantics.g"
 	
 	Expression *e = 0;
@@ -2293,31 +2293,31 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 	try {      // for error handling
 		RefLineAST __t45 = _t;
 		RefLineAST tmp59_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CDECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CDECL);
 		_t = _t->getFirstChild();
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case ID:
 		{
 			constantName = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 226 "staticsemantics.g"
 			string name = constantName->getText();
 #line 2310 "EsterelTreeParser.cpp"
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case EQUALS:
 			{
 				RefLineAST __t48 = _t;
 				RefLineAST tmp60_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),EQUALS);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),EQUALS);
 				_t = _t->getFirstChild();
-				expr = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+				expr = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 				e=expression(_t,c);
 				_t = _retTree;
 				_t = __t48;
@@ -2330,11 +2330,11 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
-			typeToken = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			typeToken = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			t=type(_t,c);
 			_t = _retTree;
 #line 229 "staticsemantics.g"
@@ -2345,21 +2345,21 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 		case COMMA:
 		{
 			RefLineAST __t49 = _t;
-			ids = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COMMA);
+			ids = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COMMA);
 			_t = _t->getFirstChild();
 			{ // ( ... )+
 			int _cnt51=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == ID)) {
 					RefLineAST tmp61_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 				}
 				else {
-					if ( _cnt51>=1 ) { goto _loop51; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt51>=1 ) { goto _loop51; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt51++;
@@ -2381,7 +2381,7 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -2390,7 +2390,7 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2399,20 +2399,20 @@ void EsterelTreeParser::constantDecl(RefLineAST _t,
 void EsterelTreeParser::signalDecl(RefLineAST _t,
 	Context *c, string direction, bool isGlobal
 ) {
-	RefLineAST signalDecl_AST_in = _t;
-	RefLineAST signalName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST expr = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST typeToken = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST func = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST pcf = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST signalDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST signalName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST expr = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST typeToken = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST func = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST pcf = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t53 = _t;
 		RefLineAST tmp62_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SDECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SDECL);
 		_t = _t->getFirstChild();
 		signalName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 243 "staticsemantics.g"
 		
@@ -2423,16 +2423,16 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 		
 #line 2425 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case COLEQUALS:
 		{
 			RefLineAST __t55 = _t;
 			RefLineAST tmp63_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COLEQUALS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COLEQUALS);
 			_t = _t->getFirstChild();
-			expr = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			expr = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			e=expression(_t,c);
 			_t = _retTree;
 			_t = __t55;
@@ -2446,7 +2446,7 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -2454,22 +2454,22 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 		TypeSymbol *t = 0; FunctionSymbol *fs = 0;
 #line 2456 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case ID:
 		{
-			typeToken = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			typeToken = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			t=type(_t,c);
 			_t = _retTree;
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case ID:
 			{
 				func = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 				_t = _t->getNextSibling();
 #line 253 "staticsemantics.g"
 				
@@ -2488,7 +2488,7 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 			case LITERAL_or:
 			case LITERAL_and:
 			{
-				pcf = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+				pcf = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 				predefinedCombineFunction(_t);
 				_t = _retTree;
 #line 262 "staticsemantics.g"
@@ -2508,7 +2508,7 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -2520,7 +2520,7 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -2548,7 +2548,7 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2557,16 +2557,16 @@ void EsterelTreeParser::signalDecl(RefLineAST _t,
 void EsterelTreeParser::functionDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST functionDecl_AST_in = _t;
-	RefLineAST functionName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST functionDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST functionName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t65 = _t;
 		RefLineAST tmp64_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),FDECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),FDECL);
 		_t = _t->getFirstChild();
 		functionName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 322 "staticsemantics.g"
 		
@@ -2580,11 +2580,11 @@ void EsterelTreeParser::functionDecl(RefLineAST _t,
 #line 2581 "EsterelTreeParser.cpp"
 		RefLineAST __t66 = _t;
 		RefLineAST tmp65_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TYPES);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TYPES);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				ts=type(_t,c);
@@ -2612,7 +2612,7 @@ void EsterelTreeParser::functionDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2621,16 +2621,16 @@ void EsterelTreeParser::functionDecl(RefLineAST _t,
 void EsterelTreeParser::procedureDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST procedureDecl_AST_in = _t;
-	RefLineAST procedureName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procedureDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST procedureName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t70 = _t;
 		RefLineAST tmp66_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PDECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PDECL);
 		_t = _t->getFirstChild();
 		procedureName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 337 "staticsemantics.g"
 		
@@ -2645,11 +2645,11 @@ void EsterelTreeParser::procedureDecl(RefLineAST _t,
 #line 2646 "EsterelTreeParser.cpp"
 		RefLineAST __t71 = _t;
 		RefLineAST tmp67_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TYPES);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TYPES);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				ts=type(_t,c);
@@ -2669,11 +2669,11 @@ void EsterelTreeParser::procedureDecl(RefLineAST _t,
 		_t = _t->getNextSibling();
 		RefLineAST __t74 = _t;
 		RefLineAST tmp68_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TYPES);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TYPES);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				ts=type(_t,c);
@@ -2696,7 +2696,7 @@ void EsterelTreeParser::procedureDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2705,16 +2705,16 @@ void EsterelTreeParser::procedureDecl(RefLineAST _t,
 void EsterelTreeParser::taskDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST taskDecl_AST_in = _t;
-	RefLineAST taskName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST taskDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST taskName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t78 = _t;
 		RefLineAST tmp69_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TADECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TADECL);
 		_t = _t->getFirstChild();
 		taskName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 353 "staticsemantics.g"
 		
@@ -2728,11 +2728,11 @@ void EsterelTreeParser::taskDecl(RefLineAST _t,
 #line 2729 "EsterelTreeParser.cpp"
 		RefLineAST __t79 = _t;
 		RefLineAST tmp70_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TYPES);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TYPES);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				ts=type(_t,c);
@@ -2752,11 +2752,11 @@ void EsterelTreeParser::taskDecl(RefLineAST _t,
 		_t = _t->getNextSibling();
 		RefLineAST __t82 = _t;
 		RefLineAST tmp71_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TYPES);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TYPES);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				ts=type(_t,c);
@@ -2779,7 +2779,7 @@ void EsterelTreeParser::taskDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2788,26 +2788,26 @@ void EsterelTreeParser::taskDecl(RefLineAST _t,
 void EsterelTreeParser::relationDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST relationDecl_AST_in = _t;
-	RefLineAST sig1 = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST sig2 = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST sig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST relationDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST sig1 = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sig2 = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case IMPLIES:
 		{
 			RefLineAST __t86 = _t;
 			RefLineAST tmp72_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),IMPLIES);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),IMPLIES);
 			_t = _t->getFirstChild();
 			sig1 = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			sig2 = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			_t = __t86;
 			_t = _t->getNextSibling();
@@ -2832,7 +2832,7 @@ void EsterelTreeParser::relationDecl(RefLineAST _t,
 		{
 			RefLineAST __t87 = _t;
 			RefLineAST tmp73_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),POUND);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),POUND);
 			_t = _t->getFirstChild();
 #line 382 "staticsemantics.g"
 			
@@ -2843,11 +2843,11 @@ void EsterelTreeParser::relationDecl(RefLineAST _t,
 			{ // ( ... )+
 			int _cnt89=0;
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_t->getType() == ID)) {
 					sig = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 					_t = _t->getNextSibling();
 #line 387 "staticsemantics.g"
 					
@@ -2862,7 +2862,7 @@ void EsterelTreeParser::relationDecl(RefLineAST _t,
 #line 2863 "EsterelTreeParser.cpp"
 				}
 				else {
-					if ( _cnt89>=1 ) { goto _loop89; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+					if ( _cnt89>=1 ) { goto _loop89; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 				}
 				
 				_cnt89++;
@@ -2875,13 +2875,13 @@ void EsterelTreeParser::relationDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -2893,10 +2893,10 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 #line 829 "staticsemantics.g"
 	Expression *e;
 #line 2896 "EsterelTreeParser.cpp"
-	RefLineAST expression_AST_in = _t;
-	RefLineAST sig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST trap = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST func = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST expression_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST sig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trap = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST func = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 831 "staticsemantics.g"
@@ -2906,13 +2906,13 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		
 #line 2908 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case Integer:
 		{
 			RefLineAST tmp74_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),Integer);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),Integer);
 			_t = _t->getNextSibling();
 #line 836 "staticsemantics.g"
 			e = new Literal(expression_AST_in->getText(), c->integer_type);
@@ -2922,7 +2922,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case FloatConst:
 		{
 			RefLineAST tmp75_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),FloatConst);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),FloatConst);
 			_t = _t->getNextSibling();
 #line 837 "staticsemantics.g"
 			e = new Literal(expression_AST_in->getText(), c->float_type);
@@ -2932,7 +2932,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case DoubleConst:
 		{
 			RefLineAST tmp76_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DoubleConst);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DoubleConst);
 			_t = _t->getNextSibling();
 #line 838 "staticsemantics.g"
 			e = new Literal(expression_AST_in->getText(), c->double_type);
@@ -2942,7 +2942,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case LITERAL_true:
 		{
 			RefLineAST tmp77_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_true);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_true);
 			_t = _t->getNextSibling();
 #line 839 "staticsemantics.g"
 			e = new LoadVariableExpression(c->true_constant);
@@ -2952,7 +2952,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case LITERAL_false:
 		{
 			RefLineAST tmp78_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_false);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_false);
 			_t = _t->getNextSibling();
 #line 840 "staticsemantics.g"
 			e = new LoadVariableExpression(c->false_constant);
@@ -2962,7 +2962,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case StringConstant:
 		{
 			RefLineAST tmp79_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),StringConstant);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),StringConstant);
 			_t = _t->getNextSibling();
 #line 841 "staticsemantics.g"
 			e = new Literal(expression_AST_in->getText(), c->string_type);
@@ -2972,7 +2972,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case ID:
 		{
 			RefLineAST tmp80_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 843 "staticsemantics.g"
 			
@@ -2992,10 +2992,10 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t190 = _t;
 			RefLineAST tmp81_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),QUESTION);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),QUESTION);
 			_t = _t->getFirstChild();
 			sig = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			_t = __t190;
 			_t = _t->getNextSibling();
@@ -3017,10 +3017,10 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t191 = _t;
 			RefLineAST tmp82_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DQUESTION);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DQUESTION);
 			_t = _t->getFirstChild();
 			trap = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			_t = __t191;
 			_t = _t->getNextSibling();
@@ -3042,10 +3042,10 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t192 = _t;
 			RefLineAST tmp83_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),CALL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),CALL);
 			_t = _t->getFirstChild();
 			func = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 876 "staticsemantics.g"
 			
@@ -3060,7 +3060,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 #line 3061 "EsterelTreeParser.cpp"
 			{ // ( ... )*
 			for (;;) {
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				if ((_tokenSet_1.member(_t->getType()))) {
 					e1=expression(_t,c);
@@ -3094,7 +3094,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t195 = _t;
 			RefLineAST tmp84_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_or);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_or);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3111,7 +3111,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t196 = _t;
 			RefLineAST tmp85_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_and);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_and);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3128,7 +3128,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t197 = _t;
 			RefLineAST tmp86_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_not);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_not);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3147,7 +3147,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t198 = _t;
 			RefLineAST tmp87_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PLUS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PLUS);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3164,12 +3164,12 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t199 = _t;
 			RefLineAST tmp88_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DASH);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DASH);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
 			{
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			switch ( _t->getType()) {
 			case 3:
@@ -3221,7 +3221,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 			}
 			default:
 			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 			}
 			}
 			}
@@ -3233,7 +3233,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t201 = _t;
 			RefLineAST tmp89_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),STAR);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),STAR);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3250,7 +3250,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t202 = _t;
 			RefLineAST tmp90_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SLASH);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SLASH);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3267,7 +3267,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t203 = _t;
 			RefLineAST tmp91_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_mod);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_mod);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3284,7 +3284,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t204 = _t;
 			RefLineAST tmp92_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),EQUALS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),EQUALS);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3301,7 +3301,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t205 = _t;
 			RefLineAST tmp93_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),NEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),NEQUAL);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3318,7 +3318,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t206 = _t;
 			RefLineAST tmp94_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LESSTHAN);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LESSTHAN);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3335,7 +3335,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t207 = _t;
 			RefLineAST tmp95_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LEQUAL);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3352,7 +3352,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t208 = _t;
 			RefLineAST tmp96_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),GREATERTHAN);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),GREATERTHAN);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3369,7 +3369,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		{
 			RefLineAST __t209 = _t;
 			RefLineAST tmp97_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),GEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),GEQUAL);
 			_t = _t->getFirstChild();
 			e1=expression(_t,c);
 			_t = _retTree;
@@ -3385,7 +3385,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		case LITERAL_pre:
 		{
 			RefLineAST tmp98_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_pre);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_pre);
 			_t = _t->getNextSibling();
 #line 943 "staticsemantics.g"
 			throw LineError(expression_AST_in, "pre not supported");
@@ -3394,7 +3394,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -3407,7 +3407,7 @@ Expression * EsterelTreeParser::expression(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3420,15 +3420,15 @@ TypeSymbol * EsterelTreeParser::type(RefLineAST _t,
 #line 400 "staticsemantics.g"
 	TypeSymbol *t;
 #line 3423 "EsterelTreeParser.cpp"
-	RefLineAST type_AST_in = _t;
-	RefLineAST type = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST type_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST type = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 401 "staticsemantics.g"
 		t = 0;
 #line 3430 "EsterelTreeParser.cpp"
 		type = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 403 "staticsemantics.g"
 		
@@ -3443,7 +3443,7 @@ TypeSymbol * EsterelTreeParser::type(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3451,49 +3451,49 @@ TypeSymbol * EsterelTreeParser::type(RefLineAST _t,
 }
 
 void EsterelTreeParser::predefinedCombineFunction(RefLineAST _t) {
-	RefLineAST predefinedCombineFunction_AST_in = _t;
+	RefLineAST predefinedCombineFunction_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 	
 	try {      // for error handling
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case PLUS:
 		{
 			RefLineAST tmp99_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PLUS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PLUS);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case STAR:
 		{
 			RefLineAST tmp100_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),STAR);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),STAR);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_or:
 		{
 			RefLineAST tmp101_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_or);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_or);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_and:
 		{
 			RefLineAST tmp102_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_and);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_and);
 			_t = _t->getNextSibling();
 			break;
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3502,16 +3502,16 @@ void EsterelTreeParser::predefinedCombineFunction(RefLineAST _t) {
 void EsterelTreeParser::trapDecl(RefLineAST _t,
 	Context *c
 ) {
-	RefLineAST trapDecl_AST_in = _t;
-	RefLineAST trapName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapDecl_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST trapName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t60 = _t;
 		RefLineAST tmp103_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),TDECL);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),TDECL);
 		_t = _t->getFirstChild();
 		trapName = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 		_t = _t->getNextSibling();
 #line 300 "staticsemantics.g"
 		
@@ -3522,14 +3522,14 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 		
 #line 3524 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case COLEQUALS:
 		{
 			RefLineAST __t62 = _t;
 			RefLineAST tmp104_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COLEQUALS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COLEQUALS);
 			_t = _t->getFirstChild();
 			e=expression(_t,c);
 			_t = _retTree;
@@ -3544,7 +3544,7 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -3552,7 +3552,7 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 		TypeSymbol *ts = NULL;
 #line 3554 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case ID:
@@ -3567,7 +3567,7 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
@@ -3585,7 +3585,7 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3594,21 +3594,21 @@ void EsterelTreeParser::trapDecl(RefLineAST _t,
 void EsterelTreeParser::procArgs(RefLineAST _t,
 	Context *c, ProcedureCall *pc
 ) {
-	RefLineAST procArgs_AST_in = _t;
-	RefLineAST var = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST procArgs_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST var = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t182 = _t;
 		RefLineAST tmp105_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),VARS);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),VARS);
 		_t = _t->getFirstChild();
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == ID)) {
 				var = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 				_t = _t->getNextSibling();
 #line 813 "staticsemantics.g"
 				
@@ -3633,14 +3633,14 @@ void EsterelTreeParser::procArgs(RefLineAST _t,
 		_t = _t->getNextSibling();
 		RefLineAST __t185 = _t;
 		RefLineAST tmp106_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ARGS);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ARGS);
 		_t = _t->getFirstChild();
 #line 824 "staticsemantics.g"
 		Expression *e;
 #line 3641 "EsterelTreeParser.cpp"
 		{ // ( ... )*
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_tokenSet_1.member(_t->getType()))) {
 				e=expression(_t,c);
@@ -3661,7 +3661,7 @@ void EsterelTreeParser::procArgs(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3673,22 +3673,22 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 #line 951 "staticsemantics.g"
 	Expression *e;
 #line 3676 "EsterelTreeParser.cpp"
-	RefLineAST sigExpression_AST_in = _t;
-	RefLineAST sig = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST sigExpression_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST sig = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 952 "staticsemantics.g"
 		Expression *e1, *e2; e = 0;
 #line 3683 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case LITERAL_and:
 		{
 			RefLineAST __t212 = _t;
 			RefLineAST tmp107_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_and);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_and);
 			_t = _t->getFirstChild();
 			e1=sigExpression(_t,c);
 			_t = _retTree;
@@ -3705,7 +3705,7 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 		{
 			RefLineAST __t213 = _t;
 			RefLineAST tmp108_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_or);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_or);
 			_t = _t->getFirstChild();
 			e1=sigExpression(_t,c);
 			_t = _retTree;
@@ -3722,7 +3722,7 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 		{
 			RefLineAST __t214 = _t;
 			RefLineAST tmp109_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_not);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_not);
 			_t = _t->getFirstChild();
 			e1=sigExpression(_t,c);
 			_t = _retTree;
@@ -3736,7 +3736,7 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 		case LITERAL_pre:
 		{
 			RefLineAST tmp110_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_pre);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_pre);
 			_t = _t->getNextSibling();
 #line 960 "staticsemantics.g"
 			throw LineError(sigExpression_AST_in, "pre not supported");
@@ -3746,7 +3746,7 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 		case ID:
 		{
 			sig = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 962 "staticsemantics.g"
 			
@@ -3761,14 +3761,14 @@ Expression * EsterelTreeParser::sigExpression(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3781,15 +3781,15 @@ Expression * EsterelTreeParser::delayExpression(RefLineAST _t,
 #line 972 "staticsemantics.g"
 	Expression *e;
 #line 3784 "EsterelTreeParser.cpp"
-	RefLineAST delayExpression_AST_in = _t;
-	RefLineAST expr2 = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST delayExpression_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST expr2 = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 973 "staticsemantics.g"
 		Expression *e1, *e2; e = 0;
 #line 3791 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case ID:
@@ -3806,7 +3806,7 @@ Expression * EsterelTreeParser::delayExpression(RefLineAST _t,
 		{
 			RefLineAST __t217 = _t;
 			RefLineAST tmp111_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_immediate);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_immediate);
 			_t = _t->getFirstChild();
 			e1=sigExpression(_t,c);
 			_t = _retTree;
@@ -3821,9 +3821,9 @@ Expression * EsterelTreeParser::delayExpression(RefLineAST _t,
 		{
 			RefLineAST __t218 = _t;
 			RefLineAST tmp112_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DELAY);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DELAY);
 			_t = _t->getFirstChild();
-			expr2 = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+			expr2 = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 			e2=expression(_t,c);
 			_t = _retTree;
 			e1=sigExpression(_t,c);
@@ -3844,14 +3844,14 @@ Expression * EsterelTreeParser::delayExpression(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3864,22 +3864,22 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 #line 989 "staticsemantics.g"
 	Expression *e;
 #line 3867 "EsterelTreeParser.cpp"
-	RefLineAST trapExpression_AST_in = _t;
-	RefLineAST trap = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST trapExpression_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST trap = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 #line 990 "staticsemantics.g"
 		Expression *e1, *e2; e = 0;
 #line 3874 "EsterelTreeParser.cpp"
 		{
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case LITERAL_and:
 		{
 			RefLineAST __t221 = _t;
 			RefLineAST tmp113_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_and);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_and);
 			_t = _t->getFirstChild();
 			e1=trapExpression(_t,c);
 			_t = _retTree;
@@ -3896,7 +3896,7 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 		{
 			RefLineAST __t222 = _t;
 			RefLineAST tmp114_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_or);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_or);
 			_t = _t->getFirstChild();
 			e1=trapExpression(_t,c);
 			_t = _retTree;
@@ -3913,7 +3913,7 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 		{
 			RefLineAST __t223 = _t;
 			RefLineAST tmp115_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_not);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_not);
 			_t = _t->getFirstChild();
 			e1=trapExpression(_t,c);
 			_t = _retTree;
@@ -3927,7 +3927,7 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 		case ID:
 		{
 			trap = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 #line 998 "staticsemantics.g"
 			
@@ -3944,14 +3944,14 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -3959,126 +3959,126 @@ Expression * EsterelTreeParser::trapExpression(RefLineAST _t,
 }
 
 void EsterelTreeParser::funcName(RefLineAST _t) {
-	RefLineAST funcName_AST_in = _t;
+	RefLineAST funcName_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 	
 	try {      // for error handling
-		if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = ASTNULL;
 		switch ( _t->getType()) {
 		case ID:
 		{
 			RefLineAST tmp116_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_and:
 		{
 			RefLineAST tmp117_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_and);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_and);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_or:
 		{
 			RefLineAST tmp118_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_or);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_or);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_not:
 		{
 			RefLineAST tmp119_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_not);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_not);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case PLUS:
 		{
 			RefLineAST tmp120_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),PLUS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),PLUS);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case DASH:
 		{
 			RefLineAST tmp121_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),DASH);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),DASH);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case STAR:
 		{
 			RefLineAST tmp122_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),STAR);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),STAR);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case SLASH:
 		{
 			RefLineAST tmp123_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),SLASH);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),SLASH);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LITERAL_mod:
 		{
 			RefLineAST tmp124_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LITERAL_mod);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LITERAL_mod);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LESSTHAN:
 		{
 			RefLineAST tmp125_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LESSTHAN);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LESSTHAN);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case GREATERTHAN:
 		{
 			RefLineAST tmp126_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),GREATERTHAN);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),GREATERTHAN);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case LEQUAL:
 		{
 			RefLineAST tmp127_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),LEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),LEQUAL);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case GEQUAL:
 		{
 			RefLineAST tmp128_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),GEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),GEQUAL);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case NEQUAL:
 		{
 			RefLineAST tmp129_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),NEQUAL);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),NEQUAL);
 			_t = _t->getNextSibling();
 			break;
 		}
 		case EQUALS:
 		{
 			RefLineAST tmp130_AST_in = _t;
-			match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),EQUALS);
+			match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),EQUALS);
 			_t = _t->getNextSibling();
 			break;
 		}
 		default:
 		{
-			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 		}
 		}
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
@@ -4087,42 +4087,42 @@ void EsterelTreeParser::funcName(RefLineAST _t) {
 void EsterelTreeParser::variableDeclList(RefLineAST _t,
 	 Context *oc, Context *nc, TypeSymbol *ts 
 ) {
-	RefLineAST variableDeclList_AST_in = _t;
-	RefLineAST variableName = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
-	RefLineAST varexpr = static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST variableDeclList_AST_in = (_t == RefLineAST(ASTNULL)) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+	RefLineAST variableName = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
+	RefLineAST varexpr = RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST);
 	
 	try {      // for error handling
 		RefLineAST __t174 = _t;
 		RefLineAST tmp131_AST_in = _t;
-		match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),VARS);
+		match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),VARS);
 		_t = _t->getFirstChild();
 		{ // ( ... )+
 		int _cnt179=0;
 		for (;;) {
-			if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+			if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 				_t = ASTNULL;
 			if ((_t->getType() == VDECL)) {
 				RefLineAST __t176 = _t;
 				RefLineAST tmp132_AST_in = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),VDECL);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),VDECL);
 				_t = _t->getFirstChild();
 				variableName = _t;
-				match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),ID);
+				match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),ID);
 				_t = _t->getNextSibling();
 #line 773 "staticsemantics.g"
 				Expression *e = 0;
 #line 4115 "EsterelTreeParser.cpp"
 				{
-				if (_t == static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+				if (_t == RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 					_t = ASTNULL;
 				switch ( _t->getType()) {
 				case COLEQUALS:
 				{
 					RefLineAST __t178 = _t;
 					RefLineAST tmp133_AST_in = _t;
-					match(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t),COLEQUALS);
+					match(ANTLR_USE_NAMESPACE(antlr)RefAST(_t),COLEQUALS);
 					_t = _t->getFirstChild();
-					varexpr = (_t == ASTNULL) ? static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
+					varexpr = (_t == ASTNULL) ? RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) : _t;
 					e=expression(_t,oc);
 					_t = _retTree;
 					_t = __t178;
@@ -4135,7 +4135,7 @@ void EsterelTreeParser::variableDeclList(RefLineAST _t,
 				}
 				default:
 				{
-					throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));
+					throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));
 				}
 				}
 				}
@@ -4156,7 +4156,7 @@ void EsterelTreeParser::variableDeclList(RefLineAST _t,
 				_t = _t->getNextSibling();
 			}
 			else {
-				if ( _cnt179>=1 ) { goto _loop179; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(static_cast<ANTLR_USE_NAMESPACE(antlr)RefAST>(_t));}
+				if ( _cnt179>=1 ) { goto _loop179; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(ANTLR_USE_NAMESPACE(antlr)RefAST(_t));}
 			}
 			
 			_cnt179++;
@@ -4168,18 +4168,13 @@ void EsterelTreeParser::variableDeclList(RefLineAST _t,
 	}
 	catch (ANTLR_USE_NAMESPACE(antlr)RecognitionException& ex) {
 		reportError(ex);
-		if ( _t != static_cast<RefLineAST>(ANTLR_USE_NAMESPACE(antlr)nullAST) )
+		if ( _t != RefLineAST(ANTLR_USE_NAMESPACE(antlr)nullAST) )
 			_t = _t->getNextSibling();
 	}
 	_retTree = _t;
 }
 
-RefLineAST EsterelTreeParser::getAST()
-{
-	return returnAST;
-}
-
-void EsterelTreeParser::initializeASTFactory( ANTLR_USE_NAMESPACE(antlr)ASTFactory& factory )
+void EsterelTreeParser::initializeASTFactory( ANTLR_USE_NAMESPACE(antlr)ASTFactory& )
 {
 }
 const char* EsterelTreeParser::tokenNames[] = {

--- a/src/EsterelTreeParser.hpp
+++ b/src/EsterelTreeParser.hpp
@@ -3,7 +3,7 @@
 
 #include <antlr/config.hpp>
 #include "EsterelTreeParserTokenTypes.hpp"
-/* $ANTLR 2.7.2: "staticsemantics.g" -> "EsterelTreeParser.hpp"$ */
+/* $ANTLR 2.7.7 (2006-11-01): "staticsemantics.g" -> "EsterelTreeParser.hpp"$ */
 #include <antlr/TreeParser.hpp>
 
 #line 1 "staticsemantics.g"
@@ -45,14 +45,14 @@ using namespace AST;
 
 
 #line 48 "EsterelTreeParser.hpp"
-class EsterelTreeParser : public ANTLR_USE_NAMESPACE(antlr)TreeParser, public EsterelTreeParserTokenTypes
+class CUSTOM_API EsterelTreeParser : public ANTLR_USE_NAMESPACE(antlr)TreeParser, public EsterelTreeParserTokenTypes
 {
 #line 125 "staticsemantics.g"
 
 #line 52 "EsterelTreeParser.hpp"
 public:
 	EsterelTreeParser();
-	void initializeASTFactory( ANTLR_USE_NAMESPACE(antlr)ASTFactory& factory );
+	static void initializeASTFactory( ANTLR_USE_NAMESPACE(antlr)ASTFactory& factory );
 	int getNumTokens() const
 	{
 		return EsterelTreeParser::NUM_TOKENS;
@@ -61,6 +61,10 @@ public:
 	{
 		if( type > getNumTokens() ) return 0;
 		return EsterelTreeParser::tokenNames[type];
+	}
+	const char* const* getTokenNames() const
+	{
+		return EsterelTreeParser::tokenNames;
 	}
 	public: void file(RefLineAST _t,
 		Modules *ms, string filename
@@ -122,7 +126,10 @@ public:
 		 Context *oc, Context *nc, TypeSymbol *ts 
 	);
 public:
-	RefLineAST getAST();
+	ANTLR_USE_NAMESPACE(antlr)RefAST getAST()
+	{
+		return ANTLR_USE_NAMESPACE(antlr)RefAST(returnAST);
+	}
 	
 protected:
 	RefLineAST returnAST;

--- a/src/EsterelTreeParserTokenTypes.hpp
+++ b/src/EsterelTreeParserTokenTypes.hpp
@@ -1,8 +1,15 @@
 #ifndef INC_EsterelTreeParserTokenTypes_hpp_
 #define INC_EsterelTreeParserTokenTypes_hpp_
 
-/* $ANTLR 2.7.2: "staticsemantics.g" -> "EsterelTreeParserTokenTypes.hpp"$ */
-struct EsterelTreeParserTokenTypes {
+/* $ANTLR 2.7.7 (2006-11-01): "staticsemantics.g" -> "EsterelTreeParserTokenTypes.hpp"$ */
+
+#ifndef CUSTOM_API
+# define CUSTOM_API
+#endif
+
+#ifdef __cplusplus
+struct CUSTOM_API EsterelTreeParserTokenTypes {
+#endif
 	enum {
 		EOF_ = 1,
 		SIGS = 4,
@@ -128,5 +135,7 @@ struct EsterelTreeParserTokenTypes {
 		Comment = 124,
 		NULL_TREE_LOOKAHEAD = 3
 	};
+#ifdef __cplusplus
 };
+#endif
 #endif /*INC_EsterelTreeParserTokenTypes_hpp_*/

--- a/src/ExpandModules.cpp
+++ b/src/ExpandModules.cpp
@@ -1,4 +1,4 @@
-#line 1686 "ExpandModules.nw"
+#line 1684 "ExpandModules.nw"
 #include <stdio.h>
 #include "ExpandModules.hpp"
 
@@ -37,7 +37,7 @@ Status FindRoots::visit(Run &s)
   roots.erase(m);
   return Status();
 }
-#line 1693 "ExpandModules.nw"
+#line 1691 "ExpandModules.nw"
   
 #line 445 "ExpandModules.nw"
 void Copier::copySymbolTable(const SymbolTable *source, SymbolTable *dest)
@@ -622,9 +622,7 @@ for ( SymbolTable::const_iterator i = moduleToCopy->variables->begin() ;
   string newName = baseName;
   int next = 1;
   while (newModule->variables->local_contains(newName)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    newName = baseName + '_' + buf;
+    newName = baseName + '_' + std::to_string(next++);
   }
   TypeSymbol *newType = newcopier.actualSymbol(oldVariable->type);
   Expression *newInitializer = newcopier.copy(oldVariable->initializer);
@@ -640,7 +638,7 @@ copiedSymbolTableMap.insert( std::make_pair(moduleToCopy->variables,
 
 #line 595 "ExpandModules.nw"
   
-#line 1189 "ExpandModules.nw"
+#line 1187 "ExpandModules.nw"
 for ( vector<Counter*>::const_iterator i = moduleToCopy->counters.begin() ;
 	i != moduleToCopy->counters.end() ; i++ ) {
   Counter *newCounter = new Counter();
@@ -652,7 +650,7 @@ for ( vector<Counter*>::const_iterator i = moduleToCopy->counters.begin() ;
   Statement *result = newcopier.copy(body);
   return result;
 }
-#line 1225 "ExpandModules.nw"
+#line 1223 "ExpandModules.nw"
 Status Copier::visit(FunctionSymbol &s)
 {
   FunctionSymbol *result = new FunctionSymbol(s.name);
@@ -676,7 +674,7 @@ Status Copier::visit(BuiltinFunctionSymbol &s)
   }
   return result;
 }
-#line 1251 "ExpandModules.nw"
+#line 1249 "ExpandModules.nw"
 Status Copier::visit(ProcedureSymbol &s)
 {
   ProcedureSymbol *result = new ProcedureSymbol(s.name);
@@ -708,7 +706,7 @@ Status Copier::visit(TaskSymbol &s)
   }
   return result;
 }
-#line 1348 "ExpandModules.nw"
+#line 1346 "ExpandModules.nw"
 Status Copier::visit(ProcedureCall &c)
 {
   ProcedureCall *result = new ProcedureCall(actualSymbol(c.procedure));
@@ -724,7 +722,7 @@ Status Copier::visit(ProcedureCall &c)
   }
   return result;
 }
-#line 1375 "ExpandModules.nw"
+#line 1373 "ExpandModules.nw"
 Status Copier::visit(StatementList &l)
 {
   StatementList *result = new StatementList();
@@ -744,7 +742,7 @@ Status Copier::visit(ParallelStatementList &l)
   }
   return result;
 }
-#line 1451 "ExpandModules.nw"
+#line 1449 "ExpandModules.nw"
 Status Copier::visit(Exec &e)
 {
   Exec *result = new Exec();
@@ -771,7 +769,7 @@ Status Copier::visit(Exec &e)
   }
   return result;
 }
-#line 1487 "ExpandModules.nw"
+#line 1485 "ExpandModules.nw"
 void Copier::copyCases(const CaseStatement &source, CaseStatement *dest)
 {  
   assert(dest);
@@ -783,7 +781,7 @@ void Copier::copyCases(const CaseStatement &source, CaseStatement *dest)
 
   dest->default_stmt = copy(source.default_stmt);
 }
-#line 1646 "ExpandModules.nw"
+#line 1644 "ExpandModules.nw"
 Status Copier::visit(FunctionCall &c)
 {
   FunctionCall *result = new FunctionCall(actualSymbol(c.callee));
@@ -794,14 +792,14 @@ Status Copier::visit(FunctionCall &c)
   }
   return result;
 }
-#line 1694 "ExpandModules.nw"
+#line 1692 "ExpandModules.nw"
   
-#line 1593 "ExpandModules.nw"
+#line 1591 "ExpandModules.nw"
 ExpressionCopier::ExpressionCopier(Expression *e, Copier *c)
   : theExpr(e), theCopier(c) { assert(e); assert(c); }
 
 Expression *ExpressionCopier::copy() { return theCopier->copy(theExpr); }
-#line 1695 "ExpandModules.nw"
+#line 1693 "ExpandModules.nw"
   
 #line 94 "ExpandModules.nw"
 Modules *find_roots_and_rewrite(Modules *m)
@@ -824,5 +822,5 @@ Modules *find_roots_and_rewrite(Modules *m)
   
   return result;
 }
-#line 1696 "ExpandModules.nw"
+#line 1694 "ExpandModules.nw"
 }

--- a/src/ExpandModules.hpp
+++ b/src/ExpandModules.hpp
@@ -1,4 +1,4 @@
-#line 1661 "ExpandModules.nw"
+#line 1659 "ExpandModules.nw"
 #ifndef _DISMANTLE_HPP
 #  define _DISMANTLE_HPP
 
@@ -119,10 +119,10 @@ Status visit(Abort &s) {
 }
 #line 128 "ExpandModules.nw"
 };
-#line 1677 "ExpandModules.nw"
+#line 1675 "ExpandModules.nw"
   class Copier;
   
-#line 1583 "ExpandModules.nw"
+#line 1581 "ExpandModules.nw"
 class ExpressionCopier {
   Expression *theExpr;
   Copier *theCopier;
@@ -130,7 +130,7 @@ public:
   ExpressionCopier(Expression*, Copier*);
   Expression *copy();
 };
-#line 1679 "ExpandModules.nw"
+#line 1677 "ExpandModules.nw"
   
 #line 346 "ExpandModules.nw"
 class Copier : public Visitor {
@@ -216,7 +216,7 @@ Status visit(Implication &e) {
 }
 #line 543 "ExpandModules.nw"
 Status visit(Run &);
-#line 1203 "ExpandModules.nw"
+#line 1201 "ExpandModules.nw"
 Status visit(TypeSymbol &s) { return new TypeSymbol(s.name); }
 
 Status visit(BuiltinTypeSymbol &s) { return new BuiltinTypeSymbol(s.name); }
@@ -229,12 +229,12 @@ Status visit(BuiltinConstantSymbol &s) {
   return new BuiltinConstantSymbol(s.name, actualSymbol(s.type), 
                                    copy(s.initializer));
 }
-#line 1218 "ExpandModules.nw"
+#line 1216 "ExpandModules.nw"
 Status visit(FunctionSymbol&);
 Status visit(BuiltinFunctionSymbol&);
 Status visit(ProcedureSymbol&);
 Status visit(TaskSymbol&);
-#line 1286 "ExpandModules.nw"
+#line 1284 "ExpandModules.nw"
 Status visit(SignalSymbol &s)
 {
   // std::cerr << "Copy signal " << s.name << std::endl;
@@ -250,15 +250,15 @@ Status visit(BuiltinSignalSymbol &s)
 	                     (SignalSymbol::kinds) s.kind,
 			     actualSymbol(s.combine));
 }
-#line 1304 "ExpandModules.nw"
+#line 1302 "ExpandModules.nw"
 Status visit(VariableSymbol &s) {
   return new VariableSymbol(s.name, actualSymbol(s.type), copy(s.initializer));
 }
-#line 1314 "ExpandModules.nw"
+#line 1312 "ExpandModules.nw"
 Status visit(Nothing &) { return new Nothing(); }
 Status visit(Pause &) { return new Pause(); }
 Status visit(Halt &) { return new Halt(); }
-#line 1322 "ExpandModules.nw"
+#line 1320 "ExpandModules.nw"
 Status visit(Emit &e) {
   return new Emit(actualSymbol(e.signal), copy(e.value));
 }
@@ -266,66 +266,66 @@ Status visit(Emit &e) {
 Status visit(Sustain &s) {
   return new Sustain(actualSymbol(s.signal), copy(s.value));
 }
-#line 1334 "ExpandModules.nw"
+#line 1332 "ExpandModules.nw"
 Status visit(Assign &a) {
   return new Assign(actualSymbol(a.variable), copy(a.value));
 }
-#line 1340 "ExpandModules.nw"
+#line 1338 "ExpandModules.nw"
 Status visit(Exit &e) { return new Exit(actualSymbol(e.trap), copy(e.value)); }
-#line 1344 "ExpandModules.nw"
+#line 1342 "ExpandModules.nw"
 Status visit(ProcedureCall &);
-#line 1370 "ExpandModules.nw"
+#line 1368 "ExpandModules.nw"
 Status visit(StatementList&);
 Status visit(ParallelStatementList&);
-#line 1399 "ExpandModules.nw"
+#line 1397 "ExpandModules.nw"
 Status visit(IfThenElse &s) {
   return new IfThenElse(copy(s.predicate), copy(s.then_part),
 			copy(s.else_part));
 }
-#line 1406 "ExpandModules.nw"
+#line 1404 "ExpandModules.nw"
 Status visit(Loop &s) { return new Loop(copy(s.body)); }
-#line 1410 "ExpandModules.nw"
+#line 1408 "ExpandModules.nw"
 Status visit(Repeat &s) {
   return new Repeat(copy(s.body), copy(s.count), s.is_positive,
                     newCounter(s.counter));
 }
-#line 1417 "ExpandModules.nw"
+#line 1415 "ExpandModules.nw"
 Status visit(LoopEach &s) {
   return new LoopEach( copy(s.body), copy(s.predicate));
 }
-#line 1423 "ExpandModules.nw"
+#line 1421 "ExpandModules.nw"
 Status visit(Every &s) {
   return new Every( copy(s.body), copy(s.predicate));
 }
-#line 1429 "ExpandModules.nw"
+#line 1427 "ExpandModules.nw"
 Status visit(Suspend &s) {
   return new Suspend( copy(s.body), copy(s.predicate));
 }
-#line 1435 "ExpandModules.nw"
+#line 1433 "ExpandModules.nw"
 Status visit(DoWatching &s) {
   return new DoWatching( copy(s.body), copy(s.predicate), copy(s.timeout));
 }
-#line 1441 "ExpandModules.nw"
+#line 1439 "ExpandModules.nw"
 Status visit(DoUpto &s) {
   return new DoUpto( copy(s.body), copy(s.predicate));
 }
-#line 1447 "ExpandModules.nw"
+#line 1445 "ExpandModules.nw"
 Status visit(Exec &);
-#line 1483 "ExpandModules.nw"
+#line 1481 "ExpandModules.nw"
 void copyCases(const CaseStatement &, CaseStatement *);
-#line 1501 "ExpandModules.nw"
+#line 1499 "ExpandModules.nw"
 Status visit(Abort &s) {
   Abort *result = new Abort(copy(s.body), s.is_weak);
   copyCases(s, result);
   return result;
 }
-#line 1509 "ExpandModules.nw"
+#line 1507 "ExpandModules.nw"
 Status visit(Await &s) {
   Await *result = new Await();
   copyCases(s, result);
   return result;
 }
-#line 1517 "ExpandModules.nw"
+#line 1515 "ExpandModules.nw"
 Status visit(Present &s) {
   Present *result = new Present();
   copyCases(s, result);
@@ -337,7 +337,7 @@ Status visit(If &s) {
   copyCases(s, result);
   return result;
 }
-#line 1533 "ExpandModules.nw"
+#line 1531 "ExpandModules.nw"
 Status visit(Var &s) {
   Var *result = new Var();
   result->symbols = new SymbolTable();
@@ -345,7 +345,7 @@ Status visit(Var &s) {
   result->body = copy(s.body);
   return result;
 }
-#line 1543 "ExpandModules.nw"
+#line 1541 "ExpandModules.nw"
 Status visit(Signal &s) {
   Signal *result = new Signal();
   result->symbols = new SymbolTable();
@@ -353,7 +353,7 @@ Status visit(Signal &s) {
   result->body = copy(s.body);
   return result;
 }
-#line 1553 "ExpandModules.nw"
+#line 1551 "ExpandModules.nw"
 Status visit(Trap &s) {
   Trap *result = new Trap();
   result->symbols = new SymbolTable();
@@ -366,9 +366,9 @@ Status visit(Trap &s) {
   }
   return result;
 }
-#line 1573 "ExpandModules.nw"
+#line 1571 "ExpandModules.nw"
 Status visit(Literal &l) { return new Literal(l.value, actualSymbol(l.type)); }
-#line 1600 "ExpandModules.nw"
+#line 1598 "ExpandModules.nw"
 Status visit(LoadVariableExpression &e) {
   // std::cerr << "copying variable load " << e.variable->name << std::endl;
   ConstantSymbol *cs = dynamic_cast<ConstantSymbol*>(e.variable);
@@ -380,7 +380,7 @@ Status visit(LoadVariableExpression &e) {
   }
   return new LoadVariableExpression(actualSymbol(e.variable));
 }
-#line 1614 "ExpandModules.nw"
+#line 1612 "ExpandModules.nw"
 Status visit(LoadSignalExpression &e) {
   return new LoadSignalExpression(e.type, actualSymbol(e.signal));
 }
@@ -388,12 +388,12 @@ Status visit(LoadSignalExpression &e) {
 Status visit(LoadSignalValueExpression &e) {
   return new LoadSignalValueExpression(actualSymbol(e.signal));
 }
-#line 1624 "ExpandModules.nw"
+#line 1622 "ExpandModules.nw"
 Status visit(Delay &d) {
   return new Delay(actualSymbol(d.type), copy(d.predicate),
 		   copy(d.count), d.is_immediate, newCounter(d.counter));
 }
-#line 1631 "ExpandModules.nw"
+#line 1629 "ExpandModules.nw"
 Status visit(UnaryOp &o) {
   return new UnaryOp(actualSymbol(o.type), o.op, copy(o.source));
 }
@@ -402,14 +402,14 @@ Status visit(BinaryOp &o) {
   return new BinaryOp(actualSymbol(o.type), o.op,
 		      copy(o.source1), copy(o.source2));
 }
-#line 1642 "ExpandModules.nw"
+#line 1640 "ExpandModules.nw"
 Status visit(FunctionCall &);
 #line 357 "ExpandModules.nw"
 };
-#line 1680 "ExpandModules.nw"
+#line 1678 "ExpandModules.nw"
   
 #line 90 "ExpandModules.nw"
 Modules *find_roots_and_rewrite(Modules *);
-#line 1681 "ExpandModules.nw"
+#line 1679 "ExpandModules.nw"
 }
 #endif

--- a/src/ExpandModules.nw
+++ b/src/ExpandModules.nw
@@ -1162,9 +1162,7 @@ for ( SymbolTable::const_iterator i = moduleToCopy->variables->begin() ;
   string newName = baseName;
   int next = 1;
   while (newModule->variables->local_contains(newName)) {
-    char buf[10];
-    sprintf(buf, "%d", next++);
-    newName = baseName + '_' + buf;
+    newName = baseName + '_' + std::to_string(next++);
   }
   TypeSymbol *newType = newcopier.actualSymbol(oldVariable->type);
   Expression *newInitializer = newcopier.copy(oldVariable->initializer);

--- a/src/GRCC2.cpp
+++ b/src/GRCC2.cpp
@@ -1,4 +1,4 @@
-#line 901 "GRCC2.nw"
+#line 893 "GRCC2.nw"
 #include "GRCC2.hpp"
 #include <set>
 #include <vector>
@@ -636,16 +636,12 @@ void split(Cluster *cluster, map<GRCNode*, Cluster*> &clusterOf,
 	assert(clusterOf.find(*j) != clusterOf.end());
 	if ( clusterOf[*j] != cluster ) {
 	  Nop *nop = new Nop();
-	  char buf[30];
-	  sprintf(buf, "_schedule_%d", cfgmap[*j]);
-	  nop->body = buf;
+	  nop->body = "_schedule_" + std::to_string(cfgmap[*j]);
 	  *nop >> nopchain;
 	  nopchain = nop;
 	  if (labelFor.find(*j) == labelFor.end()) {
 	    // Not yet marked as an entry point.
-	    char buf[30];
-	    sprintf(buf, "L%d", cfgmap[*j]);
-	    labelFor[*j] = buf;
+	    labelFor[*j] = 'L' + std::to_string(cfgmap[*j]);
 	    clusterOf[*j]->entries.push_back(*j);
 	  }
 	}
@@ -695,16 +691,12 @@ void split(Cluster *cluster, map<GRCNode*, Cluster*> &clusterOf,
 
 	    if (labelFor.find(*j) == labelFor.end()) {
 	      // Not yet marked as an entry point.
-	      char buf[30];
-	      sprintf(buf, "L%d", cfgmap[*j]);
-	      labelFor[*j] = buf;
+	      labelFor[*j] = 'L' + std::to_string(cfgmap[*j]);
 	      clusterOf[*j]->entries.push_back(*j);
 	    }
 	    
 	    Nop *nop = new Nop();
-	    char buf[30];
-	    sprintf(buf, "_schedule_%d", cfgmap[*j]);
-	    nop->body = buf;
+	    nop->body = "_schedule_" + std::to_string(cfgmap[*j]);
 	    *j = nop;
 	    nop->predecessors.push_back(node);
 	    *nop >> exitNode;
@@ -724,5 +716,5 @@ void split(Cluster *cluster, map<GRCNode*, Cluster*> &clusterOf,
   assert(exitNode->successors.size() == 0);
   assert(exitNode->predecessors.size() > 0);
 }
-#line 915 "GRCC2.nw"
+#line 907 "GRCC2.nw"
 }

--- a/src/GRCC2.hpp
+++ b/src/GRCC2.hpp
@@ -1,4 +1,4 @@
-#line 884 "GRCC2.nw"
+#line 876 "GRCC2.nw"
 #ifndef _GRCC2_HPP
 #  define _GRCC2_HPP
 
@@ -62,7 +62,7 @@ struct Level {
 void levelize(vector<Cluster*> &, vector<Level*> &);
 #line 740 "GRCC2.nw"
 void split(Cluster *, map<GRCNode*, Cluster*> &, map<GRCNode*, string> &);
-#line 893 "GRCC2.nw"
+#line 885 "GRCC2.nw"
 }
 
 #endif

--- a/src/GRCC2.nw
+++ b/src/GRCC2.nw
@@ -786,16 +786,12 @@ void split(Cluster *cluster, map<GRCNode*, Cluster*> &clusterOf,
 	assert(clusterOf.find(*j) != clusterOf.end());
 	if ( clusterOf[*j] != cluster ) {
 	  Nop *nop = new Nop();
-	  char buf[30];
-	  sprintf(buf, "_schedule_%d", cfgmap[*j]);
-	  nop->body = buf;
+	  nop->body = "_schedule_" + std::to_string(cfgmap[*j]);
 	  *nop >> nopchain;
 	  nopchain = nop;
 	  if (labelFor.find(*j) == labelFor.end()) {
 	    // Not yet marked as an entry point.
-	    char buf[30];
-	    sprintf(buf, "L%d", cfgmap[*j]);
-	    labelFor[*j] = buf;
+	    labelFor[*j] = 'L' + std::to_string(cfgmap[*j]);
 	    clusterOf[*j]->entries.push_back(*j);
 	  }
 	}
@@ -845,16 +841,12 @@ void split(Cluster *cluster, map<GRCNode*, Cluster*> &clusterOf,
 
 	    if (labelFor.find(*j) == labelFor.end()) {
 	      // Not yet marked as an entry point.
-	      char buf[30];
-	      sprintf(buf, "L%d", cfgmap[*j]);
-	      labelFor[*j] = buf;
+	      labelFor[*j] = 'L' + std::to_string(cfgmap[*j]);
 	      clusterOf[*j]->entries.push_back(*j);
 	    }
 	    
 	    Nop *nop = new Nop();
-	    char buf[30];
-	    sprintf(buf, "_schedule_%d", cfgmap[*j]);
-	    nop->body = buf;
+	    nop->body = "_schedule_" + std::to_string(cfgmap[*j]);
 	    *j = nop;
 	    nop->predecessors.push_back(node);
 	    *nop >> exitNode;

--- a/src/GRCOpt.cpp
+++ b/src/GRCOpt.cpp
@@ -1,4 +1,4 @@
-#line 1323 "GRCOpt.nw"
+#line 1332 "GRCOpt.nw"
 #include "GRCOpt.hpp"
 #include "ASTGRC.hpp"
 #include <iostream>
@@ -93,7 +93,7 @@ void bypass(STNode *n)
   n->children.clear(); 
   // delete n; // FIXME: This should work, but it causes problems
 }
-#line 1334 "GRCOpt.nw"
+#line 1343 "GRCOpt.nw"
   
 #line 254 "GRCOpt.nw"
 Simulator::Simulator(GRCgraph &gg) : g(gg)
@@ -172,7 +172,7 @@ for ( map<Sync *, set<int> >::iterator i = sync_levels.begin() ;
 
   for ( vector<GRCNode*>::iterator j = sync->successors.begin() ;
 	j != sync->successors.end() ; j++ ) {
-    if ( *j && !contains(levels, j - sync->successors.begin()) ) {
+    if ( *j && !contains(levels, static_cast<int>(j - sync->successors.begin())) ) {
        erase((*j)->predecessors, (GRCNode*) sync);
        *j = NULL;
     }
@@ -435,7 +435,7 @@ void Simulator::st_walk(STNode *n)
       ch != n->children.end(); ch++)
     st_walk(*ch);
 }
-#line 1335 "GRCOpt.nw"
+#line 1344 "GRCOpt.nw"
   
 #line 816 "GRCOpt.nw"
 void Pass::forward_dfs(GRCNode *n)
@@ -487,9 +487,9 @@ void Pass::transform()
     for (vector<GRCNode *>::reverse_iterator i = topolist.rbegin() ;
 	 i != topolist.rend() ; i++ ) (*i)->welcome(*this);
 }
-#line 1336 "GRCOpt.nw"
+#line 1345 "GRCOpt.nw"
   
-#line 1095 "GRCOpt.nw"
+#line 1104 "GRCOpt.nw"
 Status DanglingST::visit(Enter &s)
 {
   if ( !contains(stkept, s.st) ) {
@@ -507,9 +507,9 @@ Status DanglingST::visit(STSuspend &s)
   }
   return Status();
 }
-#line 1337 "GRCOpt.nw"
+#line 1346 "GRCOpt.nw"
   
-#line 984 "GRCOpt.nw"
+#line 993 "GRCOpt.nw"
 Status PruneSW::visit(Switch &s)
  {
    for ( vector<STNode*>::iterator sch = s.st->children.begin() ;
@@ -543,9 +543,9 @@ Status PruneSW::visit(Switch &s)
     
     return Status();
   }
-#line 1338 "GRCOpt.nw"
+#line 1347 "GRCOpt.nw"
   
-#line 1035 "GRCOpt.nw"
+#line 1044 "GRCOpt.nw"
 Status MergeSW::visit(Switch &s)
 {
 
@@ -587,7 +587,7 @@ Status MergeSW::visit(Switch &s)
 
   return Status();
 }
-#line 1339 "GRCOpt.nw"
+#line 1348 "GRCOpt.nw"
   
 #line 915 "GRCOpt.nw"
 STNode *STSimplify::check_st(STNode *n, STNode *realpar)
@@ -617,21 +617,30 @@ STNode *STSimplify::check_st(STNode *n, STNode *realpar)
       if(c) keep=1;
     }
     
-  if(is_simpleref)
-    if(keep) return c; else return NULL;
+  if(is_simpleref) {
+    if(keep)
+		return c;
+	else
+		return NULL;
+  }
     
-  if(keep) { stkept.insert(n); return n; } else return NULL;
+  if(keep) {
+	stkept.insert(n);
+	return n;
+  }
+  else
+	return NULL;
 }
-#line 1340 "GRCOpt.nw"
+#line 1349 "GRCOpt.nw"
   
-#line 962 "GRCOpt.nw"
+#line 971 "GRCOpt.nw"
 Status RemoveNops::visit(Nop &s){
      bypass(&s);
      return Status();
 };
-#line 1341 "GRCOpt.nw"
+#line 1350 "GRCOpt.nw"
   
-#line 1129 "GRCOpt.nw"
+#line 1138 "GRCOpt.nw"
 Status RedundantEnters::visit(Enter &s)
 {
   assert(s.st);
@@ -642,9 +651,9 @@ Status RedundantEnters::visit(Enter &s)
   }
   return Status();
 }
-#line 1342 "GRCOpt.nw"
+#line 1351 "GRCOpt.nw"
   
-#line 1158 "GRCOpt.nw"
+#line 1167 "GRCOpt.nw"
 struct Dependencies : public ASTGRC::Dependencies {
   Status visit(Sync&) { return Status(); } // disable adding sync dependencies
 };
@@ -677,7 +686,7 @@ UnobservedEmits::UnobservedEmits(Module *m, GRCgraph *g) : Pass(g, false)
       observed.insert(s);
   }
 }
-#line 1195 "GRCOpt.nw"
+#line 1204 "GRCOpt.nw"
 Status UnobservedEmits::visit(Action &s)
 {
   Emit *emit = dynamic_cast<Emit*>(s.body);
@@ -686,17 +695,17 @@ Status UnobservedEmits::visit(Action &s)
   if (exit && observed.find(exit->trap) == observed.end()) bypass(&s);
   return Status();
 }
-#line 1210 "GRCOpt.nw"
+#line 1219 "GRCOpt.nw"
 Status UnobservedEmits::visit(DefineSignal &s)
 {
   if (observed.find(s.signal) == observed.end() &&
       !(s.is_surface && s.signal->initializer)) bypass(&s);
   return Status();
 }
-#line 1343 "GRCOpt.nw"
+#line 1352 "GRCOpt.nw"
 }
 
-#line 1224 "GRCOpt.nw"
+#line 1233 "GRCOpt.nw"
 int main(int argc, char *argv[])
 {   
   try {

--- a/src/GRCOpt.hpp
+++ b/src/GRCOpt.hpp
@@ -1,4 +1,4 @@
-#line 1297 "GRCOpt.nw"
+#line 1306 "GRCOpt.nw"
 #include "IR.hpp"
 #include "AST.hpp"
 #include <set>
@@ -39,7 +39,7 @@ void delete_node(STNode *);
 void bypass(GRCNode *);
 #line 166 "GRCOpt.nw"
 void bypass(STNode *);
-#line 1310 "GRCOpt.nw"
+#line 1319 "GRCOpt.nw"
   
 #line 211 "GRCOpt.nw"
 class Simulator : public Visitor {
@@ -97,7 +97,7 @@ void st_walk(STNode *);
 #line 235 "GRCOpt.nw"
   virtual ~Simulator() {}
 };
-#line 1311 "GRCOpt.nw"
+#line 1320 "GRCOpt.nw"
   
 #line 765 "GRCOpt.nw"
 class Pass : public Visitor {
@@ -143,9 +143,9 @@ public:
   
   void transform();
 };
-#line 1312 "GRCOpt.nw"
+#line 1321 "GRCOpt.nw"
   
-#line 1084 "GRCOpt.nw"
+#line 1093 "GRCOpt.nw"
 class DanglingST : public Pass {
     std::set<STNode*> &stkept;
     Status visit(Enter &);
@@ -154,9 +154,9 @@ class DanglingST : public Pass {
     DanglingST(GRCgraph* g, std::set<STNode*> &stkept) :
 	 Pass(g, true), stkept(stkept) {}
 };
-#line 1313 "GRCOpt.nw"
+#line 1322 "GRCOpt.nw"
   
-#line 974 "GRCOpt.nw"
+#line 983 "GRCOpt.nw"
 class PruneSW : public Pass {
     std::set<STNode*> &stkept;
     Status visit(Switch &);
@@ -164,9 +164,9 @@ class PruneSW : public Pass {
     PruneSW(GRCgraph* g, std::set<STNode*> &stkept) :
 	 Pass(g, false), stkept(stkept) {}
 };
-#line 1314 "GRCOpt.nw"
+#line 1323 "GRCOpt.nw"
   
-#line 1025 "GRCOpt.nw"
+#line 1034 "GRCOpt.nw"
 class MergeSW : public Pass {
   std::set<STNode*> &stkept;
   Status visit(Switch &);
@@ -174,7 +174,7 @@ public:
   MergeSW(GRCgraph* g, std::set<STNode*> &stkept) :
     Pass(g, false), stkept(stkept) {}
 };
-#line 1315 "GRCOpt.nw"
+#line 1324 "GRCOpt.nw"
   
 #line 902 "GRCOpt.nw"
 class STSimplify {
@@ -187,25 +187,25 @@ public:
     : g(g), stkept(stkept) { assert(g); }
   void simplify() { g->selection_tree = check_st(g->selection_tree, NULL); }
 };
-#line 1316 "GRCOpt.nw"
+#line 1325 "GRCOpt.nw"
   
-#line 954 "GRCOpt.nw"
+#line 963 "GRCOpt.nw"
 class RemoveNops : public Pass {
     Status visit(Nop &);
   public:
     RemoveNops(GRCgraph *g) : Pass(g, true) {};
 };
-#line 1317 "GRCOpt.nw"
+#line 1326 "GRCOpt.nw"
   
-#line 1121 "GRCOpt.nw"
+#line 1130 "GRCOpt.nw"
 class RedundantEnters : public Pass {
   Status visit(Enter &);
 public:
   RedundantEnters(GRCgraph *g) : Pass(g, false) {}
 };
-#line 1318 "GRCOpt.nw"
+#line 1327 "GRCOpt.nw"
   
-#line 1148 "GRCOpt.nw"
+#line 1157 "GRCOpt.nw"
 class UnobservedEmits : public Pass {
   set<SignalSymbol*> observed;
   Status visit(Action &);
@@ -213,5 +213,5 @@ class UnobservedEmits : public Pass {
 public:
   UnobservedEmits(Module *, GRCgraph *);
 };
-#line 1319 "GRCOpt.nw"
+#line 1328 "GRCOpt.nw"
 }

--- a/src/GRCOpt.nw
+++ b/src/GRCOpt.nw
@@ -358,7 +358,7 @@ for ( map<Sync *, set<int> >::iterator i = sync_levels.begin() ;
 
   for ( vector<GRCNode*>::iterator j = sync->successors.begin() ;
 	j != sync->successors.end() ; j++ ) {
-    if ( *j && !contains(levels, j - sync->successors.begin()) ) {
+    if ( *j && !contains(levels, static_cast<int>(j - sync->successors.begin())) ) {
        erase((*j)->predecessors, (GRCNode*) sync);
        *j = NULL;
     }
@@ -939,10 +939,19 @@ STNode *STSimplify::check_st(STNode *n, STNode *realpar)
       if(c) keep=1;
     }
     
-  if(is_simpleref)
-    if(keep) return c; else return NULL;
+  if(is_simpleref) {
+    if(keep)
+		return c;
+	else
+		return NULL;
+  }
     
-  if(keep) { stkept.insert(n); return n; } else return NULL;
+  if(keep) {
+	stkept.insert(n);
+	return n;
+  }
+  else
+	return NULL;
 }
 @
 

--- a/src/IR.hpp
+++ b/src/IR.hpp
@@ -45,7 +45,7 @@ namespace IR {
   private:
     const std::string _className;
   public:
-    operator const std::string () { return _className; }
+    operator std::string() const { return _className; }
   };
 #line 781 "IR.nw"
   

--- a/src/IR.nw
+++ b/src/IR.nw
@@ -132,7 +132,7 @@ cast-to-const-string operator to retrieve the name of the class.
   private:
     const std::string _className;
   public:
-    operator const std::string () { return _className; }
+    operator std::string() const { return _className; }
   };
 @
 

--- a/src/Makefile.in
+++ b/src/Makefile.in
@@ -1682,6 +1682,7 @@ uninstall-man: uninstall-man1
 
 .nw.sh :
 	$(NOTANGLE) -R$@ $< > $@
+	chmod u+x $@
 
 .nw.tex :
 	$(NOWEAVE) $(NOWEAVEFLAGS) $< > $@

--- a/src/beeble_statemachine.cpp
+++ b/src/beeble_statemachine.cpp
@@ -63,9 +63,9 @@ void state_machine::onehot()
 
 #define LAST 0
 
-char *enc2[2]={"0","1"};
-char *enc3[3]={"1 -","- 1","0 0"};
-char *enc4[4]={"1 0","1 1","0 1","0 0"};
+const char *enc2[2]={"0","1"};
+const char *enc3[3]={"1 -","- 1","0 0"};
+const char *enc4[4]={"1 0","1 1","0 1","0 0"};
 
 void state_machine::fixencoding(int no_ff, char **enc)
 {

--- a/src/cec-astgrc.cpp
+++ b/src/cec-astgrc.cpp
@@ -1,4 +1,4 @@
-#line 3248 "ASTGRC.nw"
+#line 3244 "ASTGRC.nw"
 #include "IR.hpp"
 #include "AST.hpp"
 #include <stdio.h>

--- a/src/cec-eec.cpp
+++ b/src/cec-eec.cpp
@@ -798,7 +798,7 @@ public:
   SignalSymbol *NewVariable()
   {
     char new_sig_name[32];
-    char *pref = "_EECCUT_VAR";
+    const char *pref = "_EECCUT_VAR";
 
     cerr<<"A CUT!!!!!!!!!!!!!!!!\n";
     assert(0);

--- a/src/cec-expandmodules.cpp
+++ b/src/cec-expandmodules.cpp
@@ -1,6 +1,7 @@
 #include "IR.hpp"
 #include "AST.hpp"
 #include "ExpandModules.hpp"
+#include <cstring>
 #include <iostream>
 #include <string>
 

--- a/src/cec-grcc2.cpp
+++ b/src/cec-grcc2.cpp
@@ -1,4 +1,4 @@
-#line 921 "GRCC2.nw"
+#line 913 "GRCC2.nw"
 #include "AST.hpp"
 #include "GRCC2.hpp"
 #include <iostream>

--- a/src/cec-pdgccfg.cpp
+++ b/src/cec-pdgccfg.cpp
@@ -1,7 +1,8 @@
-#include <iostream>
+#include <cstdio>
+#include <cstdlib>
 #include <fstream>
-#include <stdio.h>
-#include <stdlib.h>
+#include <iostream>
+#include <limits>
 #include <set>
 #include "IR.hpp"
 #include "AST.hpp"
@@ -9,7 +10,8 @@
 using namespace AST;
 using namespace std;
 
-const int MININT=(-1)<<(2^32-1);
+const int MININT=std::numeric_limits<int>::min();
+// const int MININT=(-1)<<(2^32-1);
 
 //for schedule
 class DPSINFO
@@ -105,7 +107,7 @@ class PDG2CCFG
   int mxnode;
 
   int newvar_counter;  //new signals counter
-  char *newvar_prefix; //unique prefix for new signals
+  const char *newvar_prefix; //unique prefix for new signals
 
   set<GRCNode *> visited;
   int debug;
@@ -126,12 +128,12 @@ class PDG2CCFG
   
 public:
   PDG2CCFG(GRCNode *top, SymbolTable *symtable, GRCNode::NumMap &refmap, int mxnode):
-    top(top),symtable(symtable), refmap(refmap), mxnode(mxnode)
+    top(top),symtable(symtable), refmap(refmap), mxnode(mxnode), newvar_prefix("_DPSCUT_VAR")
   {
     debug = 0;
 
     newvar_counter = 1;
-    newvar_prefix = "_DPSCUT_VAR";
+//    newvar_prefix = "_DPSCUT_VAR";
 
   }
 

--- a/src/cec-smblif.cpp
+++ b/src/cec-smblif.cpp
@@ -66,15 +66,22 @@ void m2blif(sm* m, ostream &o)
     */
 
     // hold
-    o<<"11"; for(i=0; i<m->no_states; i++) if(m->enc_table[i][j]=='1') o<<"-"; o<<" 1\n";
+    o<<"11";
+   	for(i=0; i<m->no_states; i++)
+		if(m->enc_table[i][j]=='1')
+			o<<"-";
+	o<<" 1\n";
     // normal op
-    for(i=0; i<m->no_states; i++) if(m->enc_table[i][j]=='1'){
-      o<<"--"; 
-      for(k=0; k<m->no_states; k++) if(m->enc_table[k][j]=='1')
-	if(k==i) o<<"1"; else o<<"-";
-      o<<" 1\n";
-    }
-
+    for(i=0; i<m->no_states; i++)
+		if(m->enc_table[i][j]=='1') {
+			o<<"--";
+            for(k=0; k<m->no_states; k++)
+				if(m->enc_table[k][j]=='1') {
+					if(k==i) o<<"1";
+					else o<<"-";
+				}
+			o<<" 1\n";
+    	}
   }
 
   // build flip - flops; TO DO: ff sharing !!!

--- a/src/cec-vm.c
+++ b/src/cec-vm.c
@@ -3,12 +3,12 @@
 #include "balvm-instructions.h"
 
 unsigned char *program;
-unsigned char* threads[MAX_THREADS];
-unsigned char states[MAX_STATES];
-unsigned char joins[MAX_JOINS];
-unsigned char signals[MAX_SIGNALS];
-int stack[MAX_STACK];
-int registers[MAX_REGISTERS];
+extern unsigned char* threads[MAX_THREADS];
+extern unsigned char states[MAX_STATES];
+extern unsigned char joins[MAX_JOINS];
+extern unsigned char signals[MAX_SIGNALS];
+extern int stack[MAX_STACK];
+extern int registers[MAX_REGISTERS];
 unsigned char *testVectors;
 
 char readProgram(char* filename);

--- a/src/cverilog.cpp
+++ b/src/cverilog.cpp
@@ -179,8 +179,10 @@ namespace CVER {
 	
 	ov<<"  $monitor($time,";
 	for(vector<wire*>::iterator w=wires.begin(); w!=wires.end(); w++)
-	  if((*w)->input || (*w)->output) ov<<",\" \","<<(*w)->name; else
-	    if(debugsignals && (*w)->monitor>=monitor_level) ov<<",\" \",u_top.u_main."<<(*w)->name;
+	  if((*w)->input || (*w)->output)
+		  ov<<",\" \","<<(*w)->name;
+	  else if(debugsignals && (*w)->monitor>=monitor_level)
+		  ov<<",\" \",u_top.u_main."<<(*w)->name;
 	ov<<");\n";
     
 	// link all inputs to 0 : no stimulus
@@ -565,9 +567,12 @@ namespace CVER {
     string label;
 
     label = (input || output || monitor >= monitor_level) ? name : "";
-    if(this==w_0) label="0"; if(this==w_1) label="1";
-    if(name=="w_finished") label="STOP";
-
+    if(this==w_0)
+	   label="0";
+	if(this==w_1)
+		label="1";
+    if(name=="w_finished")
+		label="STOP";
 
     current->odot<<name<<" [ label=\""<<label<<"\" color="<<color<<" fixed_size=true height=\"0.2\" width=\"0.2\" ";
     current->odot <<" fontsize=\"10\" ]\n";

--- a/src/pdg2beeblebrox.cpp
+++ b/src/pdg2beeblebrox.cpp
@@ -1,3 +1,6 @@
+
+#include <cstring>
+
 #include "pdg2beeblebrox.hpp"
 
 

--- a/src/prblif.cpp
+++ b/src/prblif.cpp
@@ -139,14 +139,17 @@ namespace CVER{
 
       // toggle
       o<<".names "<<cenable->name<<" ";
-      for(i=t-1;i>=0;i--) o<<qname[i]<<" ";
+      for(i=t-1;i>=0;i--)
+		  o<<qname[i]<<" ";
       o<<toggle<<"\n";
-      for(i=0;i<t+1;i++)o<<"1"; o<<" 1\n";
+      for(i=0;i<t+1;i++)
+		  o<<"1";
+	  o<<" 1\n";
 
       o<<".names "<<start->name<<" "<<qname[t]<<" "<<toggle<<" "<<dname[t]<<"\n";
       // start value
       if(stbits[t]) {
-	o<<"1-- 1\n";
+		  o<<"1-- 1\n";
       }
       o<<"001 1\n";
       o<<"010 1\n";
@@ -155,9 +158,12 @@ namespace CVER{
     }
    
     o<<".names ";
-    for(i=0;i<sz;i++) o<<qname[i]<<" "; o<<alarm->name<<"\n";
-    for(i=0;i<sz;i++)o<<"1"; o<<" 1\n";
-
+    for(i=0;i<sz;i++)
+	   o<<qname[i]<<" ";
+	o<<alarm->name<<"\n";
+    for(i=0;i<sz;i++)
+		o<<"1";
+	o<<" 1\n";
   }
-
 }
+


### PR DESCRIPTION
Hello!

This is a minimal patch to get the build going. Please read the updated INSTALL document (especially the Addendum to the Defining Variables section) and use the following configure command template:

`$ ANTLR_HOME=/usr/share/java ./configure CXXFLAGS=-DANTLR_REALLY_NO_STRCASECMP`

In my case antlr.jar is located at /usr/share/java, YMMV!

Add path options to configure to adapt installation to your set-up.

The fix is minimal (mostly casts and tying down constness of char pointers -> this is bad-style C-istic C++ code, even for a pre-C++-11 code base). The other manual edits are pre-emptive to try to avoid issues due to ill-considered primitive data type ranges etc.

The largest set of changes (to the src/Esterel* files) are the result of code generation by the antlr v2 tool (v2.7.7 in particular on my Linux distro) fed with the *.g grammar files.

In principle for any .nw file in src/ we could throw away the corresponding *.[ch]pp files, and similarly for the *.g files in src/. That would reduce diff noise in future PRs (in case someone is eager to maintain CEC :-) Not me!! :-) ).